### PR TITLE
Added "http://" to url in console output

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -46,7 +46,7 @@ http.createServer(function(request, response) {
   });
 }).listen(port, host);
 
-log('http-server successfully started: '.green + host.cyan + ':'.cyan + port.toString().cyan);
+log('http-server successfully started: '.green + 'http://'.cyan + host.cyan + ':'.cyan + port.toString().cyan);
 log('Hit CTRL-C to stop the server')
 
 process.on('SIGINT', function() {


### PR DESCRIPTION
I added a small bit of code to change the output from:

```
Starting up http-server, serving . on port: 8080
http-server successfully started: localhost:8080
Hit CTRL-C to stop the server
```

to

```
Starting up http-server, serving . on port: 8080
http-server successfully started: http://localhost:8080
Hit CTRL-C to stop the server
```

The reasoning for this is that in many terminal applications, `http://url.com` will register as a link while `url.com` won't. In particular, gnome-terminal will let me right-click the http link and open it in my browser, while the link without the http won't. Getting this to register as a link in my terminal app is really handy.
