### PR TITLE
default root should not override cli args

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -2,9 +2,7 @@
 
 var HTTPServer = require('../lib/http-server').HTTPServer;
 
-var httpServer = new HTTPServer({
-  root: './public'
-});
+var httpServer = new HTTPServer();
 
 httpServer.start();
 

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -1,4 +1,4 @@
-/* 
+/*
  *
  * http-server.js - A simple static HTTP server.
  *
@@ -13,7 +13,7 @@ var colors = require('colors'),
     http = require('http');
 
 var HTTPServer = exports.HTTPServer = function (options) {
-  this.root = argv._[0] || ".";
+  this.root = argv._[0] || "./public";
   this.port = argv.p || 8080;
   this.host = argv.a || 'localhost';
   this.cache = argv.c || 3600;
@@ -24,16 +24,16 @@ var HTTPServer = exports.HTTPServer = function (options) {
   }
   this.file = new(static.Server)(this.root, { autoIndex: this.autoIndex, cache: Number(this.cache) });
 }
-  
+
 
 HTTPServer.prototype.start = function () {
   var self = this;
   if (argv.h || argv.help) {
     return showHelp();
   }
-  self.log('Starting up http-server, serving '.yellow 
-            + self.root.cyan 
-            + ' on port: '.yellow 
+  self.log('Starting up http-server, serving '.yellow
+            + self.root.cyan
+            + ' on port: '.yellow
             + self.port.toString().cyan);
   self.server = http.createServer(function(request, response) {
     request.on('end', function() {
@@ -54,10 +54,10 @@ HTTPServer.prototype.start = function () {
     });
   });
   self.server.listen(self.port);
-  self.log('http-server successfully started: '.green 
-            + 'http://'.cyan 
-            + self.host.cyan 
-            + ':'.cyan 
+  self.log('http-server successfully started: '.green
+            + 'http://'.cyan
+            + self.host.cyan
+            + ':'.cyan
             + self.port.toString().cyan);
   self.log('Hit CTRL-C to stop the server')
 }


### PR DESCRIPTION
Setting the default root in `options` overrides the cli argument.  Setting this in the constructor fixes the issue.
