### PR TITLE
[dist refactor] Remove `flatiron` dependency

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -1,12 +1,10 @@
 var fs = require('fs'),
     util = require('util'),
-    flatiron = require('flatiron'),
+    union = require('union'),
     ecstatic = require('ecstatic');
 
 var HTTPServer = exports.HTTPServer = function (options) {
   options = options || {};
-
-  flatiron.App.call(this, options);
 
   if (options.root) {
     this.root = options.root;
@@ -23,11 +21,7 @@ var HTTPServer = exports.HTTPServer = function (options) {
 
   this.cache = options.cache || 3600; // in seconds.
   this.autoIndex = options.autoIndex !== false;
-};
-util.inherits(HTTPServer, flatiron.App);
-
-HTTPServer.prototype.listen = function (port, host, callback) {
-  this.use(flatiron.plugins.http, {
+  this.server = union.createServer({
     before: [
       ecstatic(this.root, {
         autoIndex: this.autoIndex,
@@ -35,7 +29,10 @@ HTTPServer.prototype.listen = function (port, host, callback) {
       })
     ]
   });
-  return this.start(port, host, callback);
+};
+
+HTTPServer.prototype.listen = function () {
+  this.server.listen.apply(this.server, arguments);
 };
 
 HTTPServer.prototype.close = function () {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   "dependencies": {
     "colors": "*",
     "optimist": "0.2.x",
-    "flatiron": "0.1.x",
     "union": "0.1.x",
     "ecstatic": "0.1.x"
   },


### PR DESCRIPTION
`flatiron` pulls a lot of dependencies which aren't needed and which we
don't really use.
