### PR TITLE
Support serving files with default extension 

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -13,6 +13,7 @@ if (argv.h || argv.help) {
     "  -p                 Port to use [8080]",
     "  -a                 Address to use [0.0.0.0]",
     "  -i                 Display autoIndex [true]",
+    "  -e --ext           Default file extension if none supplied [none]",
     "  -s --silent        Suppress log messages from output",
     "  -h --help          Print this list and exit.",
   ].join('\n'));
@@ -34,12 +35,13 @@ if (!argv.p) {
 }
 
 function listen(port) {
-  var options = {
+  var server = httpServer.createServer({
     root: argv._[0],
     autoIndex: argv.i,
-    cache: argv.c
-  };
-  var server = httpServer.createServer(options);
+    cache: argv.c,
+    ext: argv.e || argv.ext
+  });
+
   server.listen(port, host, function() {
     log('Starting up http-server, serving '.yellow
       + server.root.cyan

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -21,11 +21,19 @@ var HTTPServer = exports.HTTPServer = function (options) {
 
   this.cache = options.cache || 3600; // in seconds.
   this.autoIndex = options.autoIndex !== false;
+
+  if (options.ext) {
+    this.ext = options.ext === true
+      ? 'html'
+      : options.ext;
+  }
+
   this.server = union.createServer({
     before: [
       ecstatic(this.root, {
         autoIndex: this.autoIndex,
-        cache: this.cache
+        cache: this.cache,
+        defaultExt: this.ext
       })
     ]
   });


### PR DESCRIPTION
Adds ability to serve files with default extension both from the `http-server` binary and programmatically.

**http-server binary**

```
  #
  # A request to /a-file will also try to serve /a-file.html
  #
  http-server /path/to/public -e

  #
  # A request to /a-file will also try to server /a-file.json
  #
  http-server /path/to/public -e json
```

**programmatic usage**

``` js
  //
  // A request to /a-file will also try to serve /a-file.html
  //  
  var server = require('http-server').createServer({
    root: '/path/to/public',
    ext: true
  });

  //
  // A request to /a-file will also try to serve /a-file.json
  //  
  var server = require('http-server').createServer({
    root: '/path/to/public',
    ext: 'json'
  });
```

**Note:** This requires the [pull-request on ecstatic to be merged](https://github.com/jesusabdullah/node-ecstatic/pull/47)
