### PR TITLE
Add rudimentary logging for #31

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-var util = require('util'),
-    colors = require('colors'),
+var colors = require('colors'),
     httpServer = require('../lib/http-server'),
     argv = require('optimist').argv,
     portfinder = require('portfinder');
@@ -29,7 +28,7 @@ var port = argv.p,
     log = (argv.s || argv.silent) ? (function () {}) : console.log,
     requestLogger;
 
- if( log ) {
+ if (log) {
    requestLogger = function(req) {
       var d = new Date();
       log('[%s] "%s %s" "%s"', (new Date).toUTCString(), req.method.cyan, req.url.cyan, req.headers['user-agent']);

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -35,7 +35,7 @@ var HTTPServer = exports.HTTPServer = function (options) {
 
   this.server = union.createServer({
     before: (options.before || []).concat([
-      function(req, res) {
+      function(req) {
          options.logFn && options.logFn(req, res);
          res.emit('next');
       },


### PR DESCRIPTION
Fixes #31. Logs obey the -s flag and utilize existing tools (no new dependencies or complexities)

![image](https://f.cloud.github.com/assets/959972/1299219/d159d298-30fe-11e3-8d2e-9bd455ae5dbe.png)
