### PR TITLE
Adding an option to launch a HTTPS server

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -21,6 +21,11 @@ if (argv.h || argv.help) {
     "  -o                 Open browser window after staring the server",
     "  -c                 Set cache time (in seconds). e.g. -c10 for 10 seconds.",
     "                     To disable caching, use -c-1.",
+    "",
+    "  -S --ssl           Enable https.",
+    "  -C --cert          Path to ssl cert file (default: cert.pem).",
+    "  -K --key           Path to ssl key file (default: key.pem).",
+    "",
     "  -h --help          Print this list and exit."
   ].join('\n'));
   process.exit();
@@ -29,6 +34,7 @@ if (argv.h || argv.help) {
 var port = argv.p || parseInt(process.env.PORT, 10),
     host = argv.a || '0.0.0.0',
     log = (argv.s || argv.silent) ? (function () {}) : console.log,
+    ssl = !!argv.S,
     requestLogger;
 
 if (!argv.s && !argv.silent) {
@@ -61,10 +67,18 @@ function listen(port) {
     options.headers = { 'Access-Control-Allow-Origin': '*' };
   }
 
+  if (argv.S) {
+    options.https = {
+      cert: argv.C || 'cert.pem',
+      key: argv.K || 'key.pem'
+    };
+  }
+
   var server = httpServer.createServer(options);
   server.listen(port, host, function() {
     log('Starting up http-server, serving '.yellow
       + server.root.cyan
+      + ((ssl) ? ' through'.yellow + ' https'.cyan : '')
       + ' on port: '.yellow
       + port.toString().cyan);
     log('Hit CTRL-C to stop the server');

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -33,7 +33,7 @@ var HTTPServer = exports.HTTPServer = function (options) {
       : options.ext;
   }
 
-  this.server = union.createServer({
+  var serverOptions = {
     before: (options.before || []).concat([
       function (req, res) {
         options.logFn && options.logFn(req, res);
@@ -48,7 +48,12 @@ var HTTPServer = exports.HTTPServer = function (options) {
       })
     ]),
     headers: this.headers || {}
-  });
+  };
+
+  if (options.https)
+    serverOptions.https = options.https;
+
+  this.server = union.createServer(serverOptions);
 };
 
 HTTPServer.prototype.listen = function () {


### PR DESCRIPTION
### Adding several options concerning HTTPS:
- -S / --ssl: launch a https server
- -C / --cert: path to cert file (default: cert.pem)
- -K / --key: path to key file (default: key.pem)

The arguments are uppercase not to collide with the current existing one.

The idea behind this pull request is to enable developers to fastly launch a https server for dev purposes (typically when working on Speech Recognition APIs or on code injection within HTTPS pages).
### How to create dummy cert and key files for dev

``` bash
openssl genrsa -out key.pem 4096
openssl req -new -key key.pem -out csr.pem -subj "/C=US/ST=California/L=San Francisco/O=Local-Company/OU=dev/CN=localhost/emailAddress=test@test.com"
openssl x509 -req -days 9999 -in csr.pem -signkey key.pem -out cert.pem
rm csr.pem
```

Then go to chrome settings to register your key (advanced settings --> HTTPS/SSL --> Manage Certificates)
Click `Import` and add your cert.pem file to register your development certificate and not be bothered anymore by chrome warnings.

Or use the `--ignore-certificate-errors` option in Chromium if you are in a hurry.
