### PR TITLE
Make -o respect specified, or default, -a value

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -70,7 +70,7 @@ function listen(port) {
     log('Hit CTRL-C to stop the server');
 
     if (argv.o) {
-      opener('http://127.0.0.1:' + port.toString());
+      opener('http://' + host.toString() + ':' + port.toString());
     }
   });
 }


### PR DESCRIPTION
Currently, `-o` always uses `127.0.0.1` as the host.
