### PR TITLE
support custom mime-type(s) via .types file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - 0.8
   - 0.10
+  - 0.12
+  - iojs
 before_install:
   - curl --location http://git.io/1OcIZA | bash -s
 branches:

--- a/README.md
+++ b/README.md
@@ -74,4 +74,6 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-r` or `--robots` Provide a /robots.txt (whose content defaults to 'User-agent: *\nDisallow: /')
 
+`-m` or `--mimetype` Define custom mime-type(s) by path to [.types](http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types) file
+
 `-h` or `--help` Print this list and exit.

--- a/bin/http-server
+++ b/bin/http-server
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
+'use strict';
+
 var colors     = require('colors'),
     httpServer = require('../lib/http-server'),
     portfinder = require('portfinder'),
-    opener = require('opener'),
-    argv = require('optimist')
+    opener     = require('opener'),
+    path       = require('path'),
+    argv       = require('optimist')
       .boolean('cors')
       .argv;
 
@@ -31,13 +34,14 @@ if (argv.h || argv.help) {
     "  -K --key           Path to ssl key file (default: key.pem).",
     "",
     "  -r --robots        Respond to /robots.txt [User-agent: *\\nDisallow: /]",
+    "  -m --mimetype      Define custom mime-type(s) [Content-Type: custom-mime-type]",
     "  -h --help          Print this list and exit."
   ].join('\n'));
   process.exit();
 }
 
 var port = argv.p || parseInt(process.env.PORT, 10),
-    host = argv.a || '0.0.0.0',
+    host = argv.a || process.env.IP || '0.0.0.0', // TODO: remove process.env.IP - just for debugging on c9
     log = (argv.s || argv.silent) ? (function () {}) : console.log,
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
@@ -73,11 +77,13 @@ function listen(port) {
     robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
     logFn: requestLogger,
-    proxy: proxy
+    proxy: proxy,
+    mimeType: argv.m || argv.mimetype,
+    cors: !!argv.cors
   };
-
-  if (argv.cors) {
-    options.cors = true;
+  
+  if(options.mimeType && typeof options.mimeType === 'string') {
+    options.mimeType = path.resolve(options.mimeType);
   }
 
   if (ssl) {
@@ -87,7 +93,13 @@ function listen(port) {
     };
   }
 
-  var server = httpServer.createServer(options);
+  var server;
+  try {
+    server = httpServer.createServer(options);
+  } catch (e) {
+    log(e.message.red);
+    process.exit(1);
+  }
   server.listen(port, host, function () {
     var canonicalHost = host === '0.0.0.0' ? '127.0.0.1' : host,
         protocol      = ssl ? 'https:' : 'http:';

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -1,5 +1,6 @@
+'use strict';
+
 var fs = require('fs'),
-    util = require('util'),
     union = require('union'),
     ecstatic = require('ecstatic'),
     httpProxy = require('http-proxy'),
@@ -26,6 +27,7 @@ var HTTPServer = exports.HTTPServer = function (options) {
   this.cache = options.cache || 3600; // in seconds.
   this.showDir = options.showDir !== 'false';
   this.autoIndex = options.autoIndex !== 'false';
+  this.mimeType = options.mimeType;
 
   if (options.ext) {
     this.ext = options.ext === true
@@ -70,6 +72,7 @@ var HTTPServer = exports.HTTPServer = function (options) {
     cache: this.cache,
     showDir: this.showDir,
     autoIndex: this.autoIndex,
+    mimeType: this.mimeType,
     defaultExt: this.ext,
     handleError: typeof options.proxy !== 'string'
   }));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A simple zero-configuration command-line http server",
   "main": "./lib/http-server",
   "repository": {
@@ -54,23 +54,27 @@
     },
     {
       "name": "Jinkwon Lee",
-      "email" : "master@bdyne.net"
+      "email": "master@bdyne.net"
+    },
+    {
+      "name": "Jon Ege Ronnenberg",
+      "email": "jon.ronnenberg@gmail.com"
     }
   ],
   "dependencies": {
     "colors": "1.0.3",
-    "optimist": "0.6.x",
-    "union": "~0.4.3",
-    "ecstatic": "~0.7.0",
+    "corser": "~2.0.0",
+    "ecstatic":"dotnetCarpenter/node-ecstatic",
     "http-proxy": "^1.8.1",
-    "portfinder": "0.4.x",
     "opener": "~1.4.0",
-    "corser": "~2.0.0"
+    "optimist": "0.6.x",
+    "portfinder": "0.4.x",
+    "union": "~0.4.3"
   },
   "devDependencies": {
-    "vows": "0.7.x",
     "request": "2.49.x",
-    "stylezero": "2.2.0"
+    "stylezero": "2.2.0",
+    "vows": "0.7.x"
   },
   "bugs": {
     "url": "https://github.com/nodeapps/http-server/issues"
@@ -81,9 +85,9 @@
       "url": "https://github.com/nodeapps/http-server/raw/master/LICENSE"
     }
   ],
-  "preferGlobal": "true",
+  "preferGlobal": true,
   "bin": {
     "http-server": "./bin/http-server",
-    "hs" : "./bin/http-server"
+    "hs": "./bin/http-server"
   }
 }

--- a/test/fixtures/root/mime.types
+++ b/test/fixtures/root/mime.types
@@ -1,0 +1,11 @@
+# This file is an example of the Apache .types file format for describing mime-types.
+# Other example: http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
+text/prs.test                           test
+video/mp4                               mp4 m4v
+video/ogg                               ogv
+video/webm                              webm
+text/cache-manifest                     manifest
+application/x-web-app-manifest+json     webapp
+application/vnd.apple.mpegURL           M3U3
+video/MP2T                              ts
+text/css                                less

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -159,7 +159,7 @@ vows.describe('http-server').addBatch({
         root: root,
         mimeType: 'fixtures/root/mime.types'
       });
-      
+
       server.listen(8083, '127.0.0.1', this.callback);
     },
     'and when asked for a .test file': {


### PR DESCRIPTION
This is my take on fixing #35, if [my upstream PR](https://github.com/jfhbrook/node-ecstatic/pull/143) lands.
I need some help though. I can't figure out how to test the feature with vows. If I start http-server, I can request files with custom mime-types but no matter what I do in [http-server-test.js](https://github.com/dotnetCarpenter/http-server/blob/ecstatic/test/http-server-test.js#L169), I get an ECONNREFUSED. I'm pretty sure it's a race condition but I can't figure out how to fix it.

Any ideas?
