### PR TITLE
add support for  X-Forward-* Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
+`-f` or `--forward` Enable X-Forward-* Headers for proxied requests. Only available with proxy setting (defaults to 'False').
+
 `-S` or `--ssl` Enable https.
 
 `-C` or `--cert` Path to ssl cert file (default: cert.pem).

--- a/bin/http-server
+++ b/bin/http-server
@@ -28,6 +28,7 @@ if (argv.h || argv.help) {
     "                     To disable caching, use -c-1.",
     "",
     "  -P --proxy         Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com",
+    "  -f --forward       Enable X-Forward-* Headers for proxy requests. Only available with proxy setting. [false]",
     "",
     "  -S --ssl           Enable https.",
     "  -C --cert          Path to ssl cert file (default: cert.pem).",
@@ -44,6 +45,7 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     log = (argv.s || argv.silent) ? (function () {}) : console.log,
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
+    xForward = proxy ? !!argv.f || !!argv.forward : false,
     requestLogger;
 
 if (!argv.s && !argv.silent) {
@@ -76,7 +78,8 @@ function listen(port) {
     robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
     logFn: requestLogger,
-    proxy: proxy
+    proxy: proxy,
+    xForward: xForward
   };
 
   if (argv.cors) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -79,7 +79,8 @@ var HTTPServer = exports.HTTPServer = function (options) {
     before.push(function (req, res) {
       proxy.web(req, res, {
         target: options.proxy,
-        changeOrigin: true
+        changeOrigin: true,
+        xfwd: options.xForward
       });
     });
   }


### PR DESCRIPTION
Hi I've added a flag which turns on the xfwd option for http-proxy. With that option the proxied requests will get additional X-Forward-\* Headers. They are necessary to proper implement a revere proxy scenario.

Thx for the great tool. 
