### PR TITLE
proxy-pass option to avoid changing Host header

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -9,6 +9,7 @@ var colors     = require('colors'),
     opener     = require('opener'),
     argv       = require('optimist')
       .boolean('cors')
+      .boolean('proxy-pass')
       .argv;
 
 var ifaces = os.networkInterfaces();
@@ -32,6 +33,7 @@ if (argv.h || argv.help) {
     '  -U --utc     Use UTC time format in log messages.',
     '',
     '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
+    '  --proxy-pass Prevents the proxy from changing host header',
     '',
     '  -S --ssl     Enable https.',
     '  -C --cert    Path to ssl cert file (default: cert.pem).',
@@ -99,7 +101,8 @@ function listen(port) {
     robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
     logFn: logger.request,
-    proxy: proxy
+    proxy: proxy,
+    proxyPass: argv['proxy-pass']
   };
 
   if (argv.cors) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -106,7 +106,7 @@ function HttpServer(options) {
     before.push(function (req, res) {
       proxy.web(req, res, {
         target: options.proxy,
-        changeOrigin: !(options['proxy-pass'] || options.proxyPass)
+        changeOrigin: !options.proxyPass
       });
     });
   }

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -106,7 +106,7 @@ function HttpServer(options) {
     before.push(function (req, res) {
       proxy.web(req, res, {
         target: options.proxy,
-        changeOrigin: true
+        changeOrigin: !(options['proxy-pass'] || options.proxyPass)
       });
     });
   }


### PR DESCRIPTION
This adds a `proxy-pass` boolean option, which prevents the proxy from changing the origin of the host header to the target URL.

See `changeOrigin` option here: https://github.com/nodejitsu/node-http-proxy#options
