### PR TITLE
Adds ability to proxy requests insecurely

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
+`--proxy-secure` Verify SSL certificates for proxied requests (defaults to true)
+
 `-S` or `--ssl` Enable https.
 
 `-C` or `--cert` Path to ssl cert file (default: cert.pem).

--- a/bin/http-server
+++ b/bin/http-server
@@ -32,6 +32,7 @@ if (argv.h || argv.help) {
     '  -U --utc     Use UTC time format in log messages.',
     '',
     '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
+    '  --proxy-secure  Verify proxied SSL certificates [true]',
     '',
     '  -S --ssl     Enable https.',
     '  -C --cert    Path to ssl cert file (default: cert.pem).',
@@ -98,9 +99,16 @@ function listen(port) {
     autoIndex: argv.i,
     robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
-    logFn: logger.request,
-    proxy: proxy
+    logFn: logger.request
   };
+
+  if (proxy) {
+    options.proxy = {
+      target: proxy,
+      secure: argv['proxy-secure'] !== 'false',
+      changeOrigin: true
+    };
+  }
 
   if (argv.cors) {
     options.cors = true;

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -98,16 +98,13 @@ function HttpServer(options) {
     autoIndex: this.autoIndex,
     defaultExt: this.ext,
     contentType: this.contentType,
-    handleError: typeof options.proxy !== 'string'
+    handleError: typeof options.proxy !== 'object'
   }));
 
-  if (typeof options.proxy === 'string') {
+  if (options.proxy) {
     var proxy = httpProxy.createProxyServer({});
     before.push(function (req, res) {
-      proxy.web(req, res, {
-        target: options.proxy,
-        changeOrigin: true
-      });
+      proxy.web(req, res, options.proxy);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "optimist": "0.6.x",
     "union": "~0.4.3",
     "ecstatic": "~1.2",
-    "http-proxy": "^1.8.1",
+    "http-proxy": "^v1.11.1",
     "portfinder": "0.4.x",
     "opener": "~1.4.0",
     "corser": "~2.0.0"


### PR DESCRIPTION
This just exposes [`http-proxy`'s `secure` option](https://github.com/nodejitsu/node-http-proxy#options) via `--proxy-secure`. See [README.md](https://github.com/johntron/http-server/blob/ebeeae8bba03f6999e13c00f43d64e0bd8f78d81/README.md#available-options).

Fixes #214
