### PR TITLE
Made it possible to handle errors when using proxy. To avoid exception.

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -109,6 +109,9 @@ function HttpServer(options) {
         changeOrigin: true
       });
     });
+    if (options.proxyErrorHandler) {
+      proxy.on('error', options.proxyErrorHandler);
+    }
   }
 
   var serverOptions = {


### PR DESCRIPTION
If the proxy forwards to a server that returns a 404 for that file, this will make the proxy throw an exception, and in return also crash http-server.
