### PR TITLE
Fixes #278: adds support for verbose access logging

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -7,6 +7,7 @@ var colors     = require('colors'),
     httpServer = require('../lib/http-server'),
     portfinder = require('portfinder'),
     opener     = require('opener'),
+    columnify  = require('columnify'),
     argv       = require('optimist')
       .boolean('cors')
       .argv;
@@ -38,6 +39,7 @@ if (argv.h || argv.help) {
     '  -K --key     Path to ssl key file (default: key.pem).',
     '',
     '  -r --robots  Respond to /robots.txt [User-agent: *\\nDisallow: /]',
+    '  -v --verbose Log out the full headers of each request along with the typical content',
     '  -h --help    Print this list and exit.'
   ].join('\n'));
   process.exit();
@@ -68,6 +70,14 @@ if (!argv.s && !argv.silent) {
           date, req.method.cyan, req.url.cyan,
           req.headers['user-agent']
         );
+        if (argv.v || argv.verbose) {
+          var headerString = columnify(req.headers,
+                                       { columns: ['Header', 'Value'] });
+          logger.info(
+            '%s',
+            headerString
+          );
+        }
       }
     }
   };

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   ],
   "dependencies": {
     "colors": "1.0.3",
+    "columnify": "^1.5.4",
     "corser": "~2.0.0",
     "ecstatic": "^1.4.0",
     "http-proxy": "^1.8.1",


### PR DESCRIPTION
Fixes #278 

Use `-v` or `--verbose` to enable verbose access logging.

Looks like this:

```
scratch/http-server - [master] » node bin/http-server -p 8000 -v
Starting up http-server, serving ./public
Available on:
  http://127.0.0.1:8000
  http://192.168.0.2:8000
Hit CTRL-C to stop the server
[Tue May 24 2016 12:54:02 GMT-0400 (EDT)] "GET /" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36"
HEADER                    VALUE
host                      localhost:8000
connection                keep-alive
cache-control             max-age=0
accept                    text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
upgrade-insecure-requests 1
user-agent                Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36
accept-encoding           gzip, deflate, sdch
accept-language           en-US,en;q=0.8
if-none-match             "2609389-210-"2016-05-22T20:20:38.000Z""
if-modified-since         Sun, 22 May 2016 20:20:38 GMT
```

Adds dependency on [`columnify`](https://www.npmjs.com/package/columnify#columnify-objects) for pretty printing the headers when enabled.
