### PR TITLE
corsHeader was changed to header, fixing XSS

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -107,7 +107,7 @@ function listen(port) {
   if (argv.cors) {
     options.cors = true;
     if (typeof argv.cors === 'string') {
-      options.corsHeaders = argv.cors;
+      options.headers = argv.cors;
     }
   }
 


### PR DESCRIPTION
When CORS was not working, I noticed that the http-server-test.js used "header" instead of "corsHeader" for the option sent to the server. This was a quick fix for my use, but by defining the entire object instead of adding to it, this will need to be revisited for those sending additional header information to the server. Once this is done, you can use CORS like this:

http-server --cors='Access-Control-Allow-Origin':'*','Access-Control-Allow-Credentials':'true'
