### PR TITLE
Pass through server.close arguments

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -139,5 +139,5 @@ HttpServer.prototype.listen = function () {
 };
 
 HttpServer.prototype.close = function () {
-  return this.server.close();
+  return this.server.close.apply(this.server, arguments);
 };


### PR DESCRIPTION
This allows library users to receive the close callback.