### PR TITLE
Enable customizable cache time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/*
 npm-debug.log
 .dir-locals.el
+.project
+.settings

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Using `npx` you can run the script without installing it first:
 
 `-o [path]` Open browser window after starting the server. Optionally provide a URL path to open. e.g.: -o /other/dir/
 
-`-c` Set cache time (in seconds) for cache-control max-age header, e.g. `-c10` for 10 seconds (defaults to `3600`). To disable caching, use `-c-1`.
+`-c` Set cache time (in seconds) for cache-control max-age header, e.g. `-c10` for 10 seconds (defaults to `3600`). To disable caching, use `-c-1. Also supports a cache function, which can be an inline function or a path to an external module. https://github.com/jfhbrook/node-ecstatic#optscache`.
 
 `-U` or `--utc` Use UTC time format in log messages.
 

--- a/bin/http-server
+++ b/bin/http-server
@@ -35,7 +35,7 @@ if (argv.h || argv.help) {
     '  -o [path]    Open browser window after starting the server.',
     '               Optionally provide a URL path to open the browser window to.',
     '  -c           Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
-    '               To disable caching, use -c-1.',
+    '               To disable caching, use -c-1. Also supports a cache function, which can be an inline function or a path to an external module. https://github.com/jfhbrook/node-ecstatic#optscache',
     '  -t           Connections timeout in seconds [120], e.g. -t60 for 1 minute.',
     '               To disable timeout, use -t0',
     '  -U --utc     Use UTC time format in log messages.',

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -69,13 +69,32 @@ function HttpServer(options) {
   }
 
   this.headers = options.headers || {};
-
+  var cacheOption = options.cache;
+  if (cacheOption && typeof cacheOption === 'string') {
+    console.info('Trying to parse cache option "' + cacheOption + '"');
+    try {
+      /* jshint evil:true */
+      var evaluated = eval(cacheOption);
+      cacheOption = evaluated;
+      console.info('Using cache option as a "' + typeof cacheOption + '"');
+    }
+    catch (e) {
+      try {
+        var required = require(cacheOption);
+        cacheOption = required;
+        console.info('Using cache option as a scipt import');
+      }
+      catch (e2) {
+        console.info('Using cache option "' + cacheOption + '" as a string');
+      }
+    }
+  }
   this.cache = (
-    options.cache === undefined ? 3600 :
+    cacheOption === undefined ? 3600 :
     // -1 is a special case to turn off caching.
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Preventing_caching
-    options.cache === -1 ? 'no-cache, no-store, must-revalidate' :
-    options.cache // in seconds.
+    cacheOption === -1 ? 'no-cache, no-store, must-revalidate' :
+    cacheOption // in seconds.
   );
   this.showDir = options.showDir !== 'false';
   this.autoIndex = options.autoIndex !== 'false';

--- a/test/cachefunc.js
+++ b/test/cachefunc.js
@@ -1,0 +1,3 @@
+module.exports = function (path) {
+  return /.*file.*/.test(path) ? 5 : 30;
+};

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -379,5 +379,105 @@ vows.describe('http-server').addBatch({
     teardown: function (server) {
       server.close();
     }
-  }
+  },
+  'When cache time is enabled': {
+        topic: function () {
+          var server = httpServer.createServer({
+            root: root,
+            cache: '10'
+          });
+          server.listen(8086);
+          this.callback(null, server);
+        },
+        'and given GET request': {
+          topic: function () {
+            request('http://127.0.0.1:8086/file', this.callback);
+          },
+          'cache max-age should be 10': function (res) {
+            assert.equal(res.headers['cache-control'], 'max-age=10');
+          }
+        },
+        teardown: function (server) {
+          server.close();
+        }
+      },
+  'When inline cache function is enabled': {
+      topic: function () {
+        var server = httpServer.createServer({
+          root: root,
+          cache: '((path) => /.*file.*/.test(path) ? 10 : 20)'
+        });
+        server.listen(8087);
+        this.callback(null, server);
+      },
+      'and given GET /file request': {
+        topic: function () {
+          request('http://127.0.0.1:8087/file', this.callback);
+        },
+        'cache max-age should be 10': function (res) {
+          assert.equal(res.headers['cache-control'], 'max-age=10');
+        }
+      },
+      'and given GET /canYouSeeMe request': {
+          topic: function () {
+            request('http://127.0.0.1:8087/canYouSeeMe', this.callback);
+          },
+          'cache max-age should be 20': function (res) {
+            assert.equal(res.headers['cache-control'], 'max-age=20');
+          }
+        },
+      teardown: function (server) {
+        server.close();
+      }
+    },
+  'When cache string is enabled': {
+    topic: function () {
+      var server = httpServer.createServer({
+        root: root,
+        cache: 'max-age=1'
+      });
+      server.listen(8088);
+      this.callback(null, server);
+    },
+    'and given GET request': {
+      topic: function () {
+        request('http://127.0.0.1:8088/file', this.callback);
+      },
+      'cache max-age should be 1': function (res) {
+        assert.equal(res.headers['cache-control'], 'max-age=1');
+      }
+    },
+    teardown: function (server) {
+      server.close();
+    }
+  },
+  'When cache function import is enabled': {
+      topic: function () {
+        var server = httpServer.createServer({
+          root: root,
+          cache: '../test/cachefunc'
+        });
+        server.listen(8089);
+        this.callback(null, server);
+      },
+      'and given GET /file request': {
+        topic: function () {
+          request('http://127.0.0.1:8089/file', this.callback);
+        },
+        'cache max-age should be 10': function (res) {
+           assert.equal(res.headers['cache-control'], 'max-age=5');
+         }
+      },
+      'and given GET /canYouSeeMe request': {
+          topic: function () {
+            request('http://127.0.0.1:8089/canYouSeeMe', this.callback);
+          },
+          'cache max-age should be 20': function (res) {
+            assert.equal(res.headers['cache-control'], 'max-age=30');
+          }
+        },
+      teardown: function (server) {
+        server.close();
+      }
+    }
 }).export(module);


### PR DESCRIPTION
Ecstatic supports passing a function as a cache argument, but http-server passes the argument as a string. Added eval to make the function work. Also updated tests.

Fixes #63