### PR TITLE
Proxy path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
-`-U` Path for which proxy is enabled. e.g.: -U /api/ (defaults to '')
+`-R` Path for which proxy is enabled. e.g.: -U /api/
 
 `-S` or `--ssl` Enable https.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
+`-U` Path for which proxy is enabled. e.g.: -U /api/ (defaults to '')
+
 `-S` or `--ssl` Enable https.
 
 `-C` or `--cert` Path to ssl cert file (default: cert.pem).

--- a/bin/http-server
+++ b/bin/http-server
@@ -33,6 +33,7 @@ if (argv.h || argv.help) {
     '  -U --utc     Use UTC time format in log messages.',
     '',
     '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
+    '  -U           Path for which proxy is enabled. e.g.: /api/ ['']',
     '',
     '  -S --ssl     Enable https.',
     '  -C --cert    Path to ssl cert file (default: cert.pem).',
@@ -49,6 +50,7 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     host = argv.a || '0.0.0.0',
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
+    proxyPath = argv.U || '',
     utc = argv.U || argv.utc,
     logger;
 
@@ -103,6 +105,7 @@ function listen(port) {
     ext: argv.e || argv.ext,
     logFn: logger.request,
     proxy: proxy,
+    proxyPath: proxyPath,
     showDotfiles: argv.dotfiles
   };
 

--- a/bin/http-server
+++ b/bin/http-server
@@ -33,7 +33,7 @@ if (argv.h || argv.help) {
     '  -U --utc     Use UTC time format in log messages.',
     '',
     '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
-    '  -U           Path for which proxy is enabled. e.g.: /api/ [\'\']',
+    '  -R           Path for which proxy is enabled. e.g.: /api/ [none]',
     '',
     '  -S --ssl     Enable https.',
     '  -C --cert    Path to ssl cert file (default: cert.pem).',
@@ -50,7 +50,6 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     host = argv.a || '0.0.0.0',
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
-    proxyPath = argv.U || '',
     utc = argv.U || argv.utc,
     logger;
 
@@ -105,7 +104,7 @@ function listen(port) {
     ext: argv.e || argv.ext,
     logFn: logger.request,
     proxy: proxy,
-    proxyPath: proxyPath,
+    proxyPath: argv.R,
     showDotfiles: argv.dotfiles
   };
 

--- a/bin/http-server
+++ b/bin/http-server
@@ -33,7 +33,7 @@ if (argv.h || argv.help) {
     '  -U --utc     Use UTC time format in log messages.',
     '',
     '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
-    '  -U           Path for which proxy is enabled. e.g.: /api/ ['']',
+    '  -U           Path for which proxy is enabled. e.g.: /api/ [\'\']',
     '',
     '  -S --ssl     Enable https.',
     '  -C --cert    Path to ssl cert file (default: cert.pem).',

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -109,7 +109,6 @@ function HttpServer(options) {
     var proxy = httpProxy.createProxyServer({});
 
     before.push(function (req, res) {
-
       // check if request URL begins with proxyPath-option
       if (req.url.substring(0, options.proxyPath.length) === options.proxyPath) {
         proxy.web(req, res, {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -109,13 +109,17 @@ function HttpServer(options) {
     var proxy = httpProxy.createProxyServer({});
 
     before.push(function (req, res) {
-      // check if request URL begins with proxyPath-option
-      if (req.url.substring(0, options.proxyPath.length) === options.proxyPath) {
-        proxy.web(req, res, {
-          target: options.proxy,
-          changeOrigin: true
-        });
+      var shouldNotProxy =
+        options.proxyPath && req.url.substring(0, options.proxyPath.length) !== options.proxyPath;
+
+      if (shouldNotProxy) {
+        return;
       }
+
+      proxy.web(req, res, {
+        target: options.proxy,
+        changeOrigin: true
+      });
     });
   }
 

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -107,11 +107,16 @@ function HttpServer(options) {
 
   if (typeof options.proxy === 'string') {
     var proxy = httpProxy.createProxyServer({});
+
     before.push(function (req, res) {
-      proxy.web(req, res, {
-        target: options.proxy,
-        changeOrigin: true
-      });
+
+      // check if request URL begins with proxyPath-option
+      if (req.url.substring(0, options.proxyPath.length) === options.proxyPath) {
+        proxy.web(req, res, {
+          target: options.proxy,
+          changeOrigin: true
+        });
+      }
     });
   }
 


### PR DESCRIPTION
Add new "proxy path" `-R` option, which you can use to specify a certain path for which the requests are proxied. Other paths are not proxied.

Example:

If I want to proxy only requests done to path `/api/`, I can set `-R /api/`. Then:

GET /a.html -> not proxied
GET /api/data -> proxied

Solves issue: https://github.com/indexzero/http-server/issues/280