### PR TITLE
add ability to pass proxyOptions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
+`--proxyOptions` Pass proxy [options](https://github.com/nodejitsu/node-http-proxy#options) using nested dotted objects. e.g.: --proxyOptions.secure false
+
 `-S` or `--ssl` Enable https.
 
 `-C` or `--cert` Path to ssl cert file (default: `cert.pem`).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
-`--proxyOptions` Pass proxy [options](https://github.com/nodejitsu/node-http-proxy#options) using nested dotted objects. e.g.: --proxyOptions.secure false
+`--proxyOptions` Pass proxy [options](https://github.com/http-party/node-http-proxy#options) using nested dotted objects. e.g.: --proxyOptions.secure false
 
 `-S` or `--ssl` Enable https.
 

--- a/bin/http-server
+++ b/bin/http-server
@@ -33,6 +33,7 @@ if (argv.h || argv.help) {
     '  -U --utc     Use UTC time format in log messages.',
     '',
     '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
+    '  --proxyOptions  Pass options to proxy using nested dotted objects. e.g.: --proxyOptions.secure false',
     '',
     '  -S --ssl     Enable https.',
     '  -C --cert    Path to ssl cert file (default: cert.pem).',
@@ -49,8 +50,22 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     host = argv.a || '0.0.0.0',
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
+    proxyOptions = argv.proxyOptions,
     utc = argv.U || argv.utc,
     logger;
+
+var proxyOptionsBooleanProps = [
+  'ws', 'xfwd', 'secure', 'toProxy', 'prependPath', 'ignorePath', 'changeOrigin',
+  'preserveHeaderKeyCase', 'followRedirects', 'selfHandleResponse'
+];
+
+if (proxyOptions) {
+  Object.keys(proxyOptions).forEach(function (key) {
+    if (proxyOptionsBooleanProps.indexOf(key) > -1) {
+      proxyOptions[key] = proxyOptions[key] === 'true';
+    }
+  });
+}
 
 if (!argv.s && !argv.silent) {
   logger = {
@@ -103,6 +118,7 @@ function listen(port) {
     ext: argv.e || argv.ext,
     logFn: logger.request,
     proxy: proxy,
+    proxyOptions: proxyOptions,
     showDotfiles: argv.dotfiles
   };
 
@@ -145,7 +161,12 @@ function listen(port) {
     }
 
     if (typeof proxy === 'string') {
-      logger.info('Unhandled requests will be served from: ' + proxy);
+      if (proxyOptions) {
+        logger.info('Unhandled requests will be served from: ' + proxy + '. Options: ' + JSON.stringify(proxyOptions));
+      }
+      else {
+        logger.info('Unhandled requests will be served from: ' + proxy);
+      }
     }
 
     logger.info('Hit CTRL-C to stop the server');

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -106,8 +106,8 @@ function HttpServer(options) {
   }));
 
   if (typeof options.proxy === 'string') {
-    var httpProxyOptions = options.httpProxyOptions || {};
-    var proxy = httpProxy.createProxyServer(httpProxyOptions);
+    var proxyOptions = options.proxyOptions || {};
+    var proxy = httpProxy.createProxyServer(proxyOptions);
     before.push(function (req, res) {
       proxy.web(req, res, {
         target: options.proxy,

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -106,7 +106,8 @@ function HttpServer(options) {
   }));
 
   if (typeof options.proxy === 'string') {
-    var proxy = httpProxy.createProxyServer({});
+    var httpProxyOptions = options.httpProxyOptions || {};
+    var proxy = httpProxy.createProxyServer(httpProxyOptions);
     before.push(function (req, res) {
       proxy.web(req, res, {
         target: options.proxy,


### PR DESCRIPTION
http-proxy library that is used in http-server support [options](https://github.com/nodejitsu/node-http-proxy#options).

This PR adds abilities to pass proxy options via cli or programmatically (helps in cases such like https://github.com/divhide/node-grunt-http-server)

Fixes #214, fixes #246