### PR TITLE
Support custom mime types (content-type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-e` or `--ext` Default file extension if none supplied (defaults to `html`)
 
+`-m` or `--mime` JSON for mimetype mapping. e.g: `-m '{"application/wasm": ["wasm"]}'`
+
 `-s` or `--silent` Suppress log messages from output
 
 `--cors` Enable CORS via the `Access-Control-Allow-Origin` header

--- a/bin/http-server
+++ b/bin/http-server
@@ -24,6 +24,7 @@ if (argv.h || argv.help) {
     '  -i           Display autoIndex [true]',
     '  -g --gzip    Serve gzip files when possible [false]',
     '  -e --ext     Default file extension if none supplied [none]',
+    '  -m --mime    JSON for mimetype mapping. e.g: -m \'{"application/wasm": ["wasm"]}\'',
     '  -s --silent  Suppress log messages from output',
     '  --cors[=headers]   Enable CORS via the "Access-Control-Allow-Origin" header',
     '                     Optionally provide CORS headers list separated by commas',
@@ -101,6 +102,7 @@ function listen(port) {
     gzip: argv.g || argv.gzip,
     robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
+    mimeTypes: argv.m || argv.mime,
     logFn: logger.request,
     proxy: proxy,
     showDotfiles: argv.dotfiles

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -49,6 +49,7 @@ function HttpServer(options) {
   this.showDotfiles = options.showDotfiles;
   this.gzip = options.gzip === true;
   this.contentType = options.contentType || 'application/octet-stream';
+  this.mimeTypes = options.mimeTypes;
 
   if (options.ext) {
     this.ext = options.ext === true
@@ -102,6 +103,7 @@ function HttpServer(options) {
     defaultExt: this.ext,
     gzip: this.gzip,
     contentType: this.contentType,
+    mimeTypes: this.mimeTypes,
     handleError: typeof options.proxy !== 'string'
   }));
 


### PR DESCRIPTION
Just pass the mimeTypes option to node-ecstatic.