### PR TITLE
add middleware option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-r` or `--robots` Provide a /robots.txt (whose content defaults to `User-agent: *\nDisallow: /`)
 
+`--middleware` Support custom [union](https://www.npmjs.com/package/union) middleware. if you pass `returnIndex`, the http-server will serve `index.html` for all requests except static. For example, `--middleware=returnIndex`. `--middleware=mw1.js --middleware=mw2.js`
+
 `-h` or `--help` Print this list and exit.
 
 ## Magic Files

--- a/bin/http-server
+++ b/bin/http-server
@@ -40,6 +40,7 @@ if (argv.h || argv.help) {
     '',
     '  -r --robots  Respond to /robots.txt [User-agent: *\\nDisallow: /]',
     '  --no-dotfiles  Do not show dotfiles',
+    '  --middleware[=middleware.js]  Middleware for http server',
     '  -h --help    Print this list and exit.'
   ].join('\n'));
   process.exit();
@@ -103,7 +104,8 @@ function listen(port) {
     ext: argv.e || argv.ext,
     logFn: logger.request,
     proxy: proxy,
-    showDotfiles: argv.dotfiles
+    showDotfiles: argv.dotfiles,
+    middleware: argv.middleware
   };
 
   if (argv.cors) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -4,6 +4,7 @@ var fs = require('fs'),
     union = require('union'),
     ecstatic = require('ecstatic'),
     httpProxy = require('http-proxy'),
+    path = require('path'),
     corser = require('corser');
 
 //
@@ -91,6 +92,17 @@ function HttpServer(options) {
 
       res.emit('next');
     });
+  }
+
+  if (options.middleware) {
+    if (typeof options.middleware === 'object' && options.middleware.length) {
+      options.middleware.forEach(function (middlewareFile) {
+        before.push(require(path.join(process.cwd(), middlewareFile)));
+      })
+    }
+    if (typeof options.middleware === 'string') {
+      before.push(require(path.join(process.cwd(), options.middleware)));
+    }
   }
 
   before.push(ecstatic({

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -103,7 +103,7 @@ function HttpServer(options) {
         else {
           before.push(require(path.join(process.cwd(), middlewareFile)));
         }
-      })
+      });
     }
     if (typeof options.middleware === 'string') {
       if (options.middleware === 'returnIndex') {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -99,18 +99,19 @@ function HttpServer(options) {
       options.middleware.forEach(function (middlewareFile) {
         if (middlewareFile === 'returnIndex') {
           before.push(require(path.join(__dirname, '../middlewares/returnIndex')));
-        } else {
+        }
+        else {
           before.push(require(path.join(process.cwd(), middlewareFile)));
         }
       })
     }
     if (typeof options.middleware === 'string') {
-        if (options.middleware === 'returnIndex') {
-          before.push(require(path.join(__dirname, '../middlewares/returnIndex')));
-        } else {
-          before.push(require(path.join(process.cwd(), options.middleware)));
-        }
-      
+      if (options.middleware === 'returnIndex') {
+        before.push(require(path.join(__dirname, '../middlewares/returnIndex')));
+      }
+      else {
+        before.push(require(path.join(process.cwd(), options.middleware)));
+      }
     }
   }
 

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -97,11 +97,20 @@ function HttpServer(options) {
   if (options.middleware) {
     if (typeof options.middleware === 'object' && options.middleware.length) {
       options.middleware.forEach(function (middlewareFile) {
-        before.push(require(path.join(process.cwd(), middlewareFile)));
+        if (middlewareFile === 'returnIndex') {
+          before.push(require(path.join(__dirname, '../middlewares/returnIndex')));
+        } else {
+          before.push(require(path.join(process.cwd(), middlewareFile)));
+        }
       })
     }
     if (typeof options.middleware === 'string') {
-      before.push(require(path.join(process.cwd(), options.middleware)));
+        if (options.middleware === 'returnIndex') {
+          before.push(require(path.join(__dirname, '../middlewares/returnIndex')));
+        } else {
+          before.push(require(path.join(process.cwd(), options.middleware)));
+        }
+      
     }
   }
 

--- a/middlewares/returnIndex.js
+++ b/middlewares/returnIndex.js
@@ -2,11 +2,11 @@
 var fs = require('fs'),
     path = require('path');
 
-function webpack (req, res) {
+function returnIndex (req, res) {
     if (req.url.search(/\./) === -1) {
         return res.end(fs.readFileSync(path.join(process.cwd(), 'index.html')));
     }
     res.emit('next');
 }
-module.exports = webpack;
+module.exports = returnIndex;
 

--- a/middlewares/webpack.js
+++ b/middlewares/webpack.js
@@ -1,0 +1,12 @@
+
+var fs = require('fs'),
+    path = require('path');
+
+function webpack (req, res) {
+    if (req.url.search(/\./) === -1) {
+        return res.end(fs.readFileSync(path.join(process.cwd(), 'index.html')));
+    }
+    res.emit('next');
+}
+module.exports = webpack;
+


### PR DESCRIPTION
Anyone just want to serve index.html after webpack build, the router was management by front end developer. So I add middleware option, and write `returnIndex.js` in `middleware` directory.