### PR TITLE
add stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,27 @@
+# probot-stale configuration -- closes issues and PRs that have gone stale
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 10
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+
+# Label to use when marking an issue as stale
+staleLabel: stale
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed due to inactivity. Feel free to
+  re-open and comment if this issue is still relevant or becomes relevant again
+  in the future


### PR DESCRIPTION
This would configure [stale bot](https://github.com/apps/stale), which would then be added to this repository. This would help cut down on the number of issues and PRs we have open right now.

After acceptance and merging, I can add the bot integration.