### PR TITLE
add --overlay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Using `npx` you can run the script without installing it first:
 
 `-r` or `--robots` Provide a /robots.txt (whose content defaults to `User-agent: *\nDisallow: /`)
 
+`--overlay` Add an overlay folder. Any requested file is previously searched in this folder and if does not exists then is searched in the default root folder.
+
 `-h` or `--help` Print this list and exit.
 
 ## Magic Files

--- a/bin/http-server
+++ b/bin/http-server
@@ -40,6 +40,7 @@ if (argv.h || argv.help) {
     '',
     '  -r --robots  Respond to /robots.txt [User-agent: *\\nDisallow: /]',
     '  --no-dotfiles  Do not show dotfiles',
+    '  --overlay    Add overlay folder',
     '  -h --help    Print this list and exit.'
   ].join('\n'));
   process.exit();
@@ -103,7 +104,8 @@ function listen(port) {
     ext: argv.e || argv.ext,
     logFn: logger.request,
     proxy: proxy,
-    showDotfiles: argv.dotfiles
+    showDotfiles: argv.dotfiles,
+    overlay: argv.overlay,
   };
 
   if (argv.cors) {

--- a/bin/http-server
+++ b/bin/http-server
@@ -105,7 +105,7 @@ function listen(port) {
     logFn: logger.request,
     proxy: proxy,
     showDotfiles: argv.dotfiles,
-    overlay: argv.overlay,
+    overlay: argv.overlay
   };
 
   if (argv.cors) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -49,6 +49,7 @@ function HttpServer(options) {
   this.showDotfiles = options.showDotfiles;
   this.gzip = options.gzip === true;
   this.contentType = options.contentType || 'application/octet-stream';
+  this.overlay = options.overlay;
 
   if (options.ext) {
     this.ext = options.ext === true
@@ -91,6 +92,20 @@ function HttpServer(options) {
 
       res.emit('next');
     });
+  }
+
+  if (this.overlay) {
+    before.push(ecstatic({
+      root: this.overlay,
+      cache: this.cache,
+      showDir: false,
+      showDotfiles: false,
+      autoIndex: this.autoIndex,
+      defaultExt: this.ext,
+      gzip: this.gzip,
+      contentType: this.contentType,
+      handleError: typeof options.proxy !== 'string'
+    }));  
   }
 
   before.push(ecstatic({

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -105,7 +105,7 @@ function HttpServer(options) {
       gzip: this.gzip,
       contentType: this.contentType,
       handleError: typeof options.proxy !== 'string'
-    }));  
+    }));
   }
 
   before.push(ecstatic({

--- a/test/fixtures/overlay/canYouSeeMe
+++ b/test/fixtures/overlay/canYouSeeMe
@@ -1,0 +1,2 @@
+I bet you can. I'm in your index. Overlay.
+


### PR DESCRIPTION
Add the possibility to specify an optional --overlay folder, if the file to serve exists in this folder this file overlay the base file in the root folder