### PR TITLE
add process title

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -14,6 +14,8 @@ var colors     = require('colors/safe'),
 
 var ifaces = os.networkInterfaces();
 
+process.title = 'http-server';
+
 if (argv.h || argv.help) {
   console.log([
     'usage: http-server [path] [options]',


### PR DESCRIPTION
set process title to 'http-server' so it can be easily killed.

Fixes #333