### PR TITLE
require at least node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "keywords": [
     "cli",
-    "command"
+    "command",
+    "http",
+    "server"
   ],
   "scripts": {
     "start": "node ./bin/http-server",
@@ -20,6 +22,9 @@
     "lib",
     "bin"
   ],
+  "engines": {
+    "node": ">=6"
+  },
   "contributors": [
     {
       "name": "Charlie Robbins",


### PR DESCRIPTION
I think Node@6 is a reasonable minimum, even though it's not supported for much longer. Earlier releases may have issues that a simple http server doesn't need to accommodate. Instead, we should require that users of `http-server` only use the latest versions of Node.

Fixes #232 
