### PR TITLE
Move to `ecstatic` v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "basic-auth": "^1.0.3",
     "colors": "^1.3.3",
     "corser": "^2.0.1",
-    "ecstatic": "^3.3.0",
+    "ecstatic": "^4.1.2",
     "http-proxy": "^1.17.0",
     "opener": "^1.5.1",
     "optimist": "~0.6.1",


### PR DESCRIPTION
This is a new internal branch version of #520, moved here to make multiple contributions simpler. There are breaking changes but we don't yet know what exactly they are. At the moment, simply upgrading to ecstatic v4 causes http-server to stop serving content, but no errors are thrown.

**To contribute to moving to ecstatic v4, make PRs against _this_ branch (`use_ecstatic_v4`), _not_ `master`.**

Related, ecstatic unpublished their v3.x versions (#521), which is causing fresh installs of http-server to fail. Upgrading to v4 would fix these issues, but it would be better for ecstatic to republish a v3.x version with the security fix (jfhbrook/node-ecstatic#255).

fixes #518, fixes #461, fixes #512, fixes #480 

