### PR TITLE
Send Accept-Ranges: bytes with every response

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -135,6 +135,10 @@ function listen(port) {
       key: argv.K || argv.key || 'key.pem'
     };
   }
+    
+  options.headers = {
+    'Accept-Ranges': 'bytes'
+  };
 
   var server = httpServer.createServer(options);
   server.listen(port, host, function () {

--- a/bin/http-server
+++ b/bin/http-server
@@ -136,10 +136,6 @@ function listen(port) {
     };
   }
 
-  options.headers = {
-    'Accept-Ranges': 'bytes'
-  };
-
   var server = httpServer.createServer(options);
   server.listen(port, host, function () {
     var canonicalHost = host === '0.0.0.0' ? '127.0.0.1' : host,

--- a/bin/http-server
+++ b/bin/http-server
@@ -135,7 +135,7 @@ function listen(port) {
       key: argv.K || argv.key || 'key.pem'
     };
   }
-    
+
   options.headers = {
     'Accept-Ranges': 'bytes'
   };

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -44,7 +44,7 @@ function HttpServer(options) {
   }
 
   this.headers = options.headers || {};
-	this.headers['Accept-Ranges'] = 'bytes';
+  this.headers['Accept-Ranges'] = 'bytes';
 
   this.cache = (
     options.cache === undefined ? 3600 :

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -44,6 +44,7 @@ function HttpServer(options) {
   }
 
   this.headers = options.headers || {};
+	this.headers['Accept-Ranges'] = 'bytes';
 
   this.cache = (
     options.cache === undefined ? 3600 :


### PR DESCRIPTION
**Please ensure that your pull request fulfills these requirements:**
- [x] The pull request is being made against the `master` branch
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the purpose of this pull request? (bug fix, enhancement, new feature,...)**

Enhancement

<!--
    Link to the issue this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
-->

**What changes did you make?**

Now `Accept-Ranges: bytes` header is sent with every response by default.

**Provide some example code that this change will affect, if applicable:**

N/A

<!-- Paste the example code here: -->

**Is there anything you'd like reviewers to focus on?**

I think sending `Accept-Ranges: bytes` with every response is pretty benign, but surely the behaviour of some programs might be affected with this header (*i.e.* they might try to stream instead of downloading the whole file). If this is a concern, a new command-line flag can be added.

**Please provide testing instructions, if applicable:**

N/A