### PR TITLE
Add support for Access-Control-Expose-Headers using 'cors' configurat…

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -99,12 +99,17 @@ function HttpServer(options) {
   if (options.cors) {
     this.headers['Access-Control-Allow-Origin'] = '*';
     this.headers['Access-Control-Allow-Headers'] = 'Origin, X-Requested-With, Content-Type, Accept, Range';
+    this.headers['Access-Control-Expose-Headers'] = 'Origin, X-Requested-With, Content-Type, Accept, Range';
     if (options.corsHeaders) {
       options.corsHeaders.split(/\s*,\s*/)
-          .forEach(function (h) { this.headers['Access-Control-Allow-Headers'] += ', ' + h; }, this);
+          .forEach(function (h) {
+            this.headers['Access-Control-Allow-Headers'] += ', ' + h;
+            this.headers['Access-Control-Expose-Headers'] += ', ' + h;
+          }, this);
     }
     before.push(corser.create(options.corsHeaders ? {
-      requestHeaders: this.headers['Access-Control-Allow-Headers'].split(/\s*,\s*/)
+      requestHeaders: this.headers['Access-Control-Allow-Headers'].split(/\s*,\s*/),
+      responseHeaders: this.headers['Access-Control-Expose-Headers'].split(/\s*,\s*/)
     } : null));
   }
 


### PR DESCRIPTION
Fix #545. Supply 'corser' with a similar set of responseHeaders from the 'cors' options. 