### PR TITLE
Support mime

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -28,6 +28,7 @@ if (argv.h || argv.help) {
     '               If both brotli and gzip are enabled, brotli takes precedence',
     '  -e --ext     Default file extension if none supplied [none]',
     '  -s --silent  Suppress log messages from output',
+    '  --mime="<JSON>" Mime types supplied as JSON (e.g { "text/plain": [ "txt", "csv" ] })',
     '  --cors[=headers]   Enable CORS via the "Access-Control-Allow-Origin" header',
     '                     Optionally provide CORS headers list separated by commas',
     '  -o [path]    Open browser window after starting the server.',
@@ -106,6 +107,9 @@ else {
 }
 
 function listen(port) {
+
+  console.log(argv)
+
   var options = {
     root: argv._[0],
     cache: argv.c,
@@ -115,6 +119,7 @@ function listen(port) {
     brotli: argv.b || argv.brotli,
     robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
+    mimeTypes: argv.mime ? JSON.parse(argv.mime) : undefined,
     logFn: logger.request,
     proxy: proxy,
     showDotfiles: argv.dotfiles,

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -6,6 +6,7 @@ var fs = require('fs'),
     auth = require('basic-auth'),
     httpProxy = require('http-proxy'),
     corser = require('corser'),
+    mime = require('mime'),
     secureCompare = require('secure-compare');
 
 //
@@ -57,7 +58,7 @@ function HttpServer(options) {
   this.showDotfiles = options.showDotfiles;
   this.gzip = options.gzip === true;
   this.brotli = options.brotli === true;
-  this.contentType = options.contentType || 'application/octet-stream';
+  this.mimeTypes = options.mimeTypes;
 
   if (options.ext) {
     this.ext = options.ext === true
@@ -137,7 +138,7 @@ function HttpServer(options) {
     defaultExt: this.ext,
     gzip: this.gzip,
     brotli: this.brotli,
-    contentType: this.contentType,
+    mimeTypes: this.mimeTypes,
     handleError: typeof options.proxy !== 'string'
   }));
 


### PR DESCRIPTION
Adds support for mime types using `--mime=<JSON string>`.

Example:

```
http-server --mime='{ "text/plain": [ "txt", "md" ] }'
```