### PR TITLE
force to use ecstatic v3.3.2 in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -870,9 +870,9 @@
       }
     },
     "ecstatic": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.0.tgz",
-      "integrity": "sha512-EblWYTd+wPIAMQ0U4oYJZ7QBypT9ZUIwpqli0bKDjeIIQnXDBK2dXtZ9yzRCOlkW1HkO8gn7/FxLK1yPIW17pw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
       "requires": {
         "he": "^1.1.1",
         "mime": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "basic-auth": "^1.0.3",
     "colors": "^1.3.3",
     "corser": "^2.0.1",
-    "ecstatic": "^3.3.0",
+    "ecstatic": "^3.3.2",
     "http-proxy": "^1.17.0",
     "opener": "^1.5.1",
     "optimist": "~0.6.1",


### PR DESCRIPTION
**Please ensure that your pull request fulfills these requirements:**
- [x] The pull request is being made against the `master` branch
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the purpose of this pull request? (bug fix, enhancement, new feature,...)**

force to use `ecstatic` v3.3.2 in tests

Same as https://github.com/http-party/http-server/issues/525#issuecomment-551301695, the version of  `ecstatic` used in tests is different from it when installing `http-server` globally or as a dependency. 

#525 only appears when using `ecstatic` v3.3.2 .
It is very confusing in tests.

**What changes did you make?**

change the version of `ecstatic` in ``package-lock.json`` to 3.3.2
