### PR TITLE
Test on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ git:
 os:
   - linux
   - windows
+  - osx
 
 before_install:
   - travis_retry npm install


### PR DESCRIPTION
Adds `osx` as a test OS for Travis CI.

I'd like to test on BSD as well, but as far as I can tell Travis doesn't
and won't support it. Supporting OSX should sort of handle BSD testing,
though it's no substitute for the real thing.

**Please ensure that your pull request fulfills these requirements:**
- [x] The pull request is being made against the `master` branch
- [x] Tests for the changes have been added (for bug fixes / features)
