### PR TITLE
Only add logFn function to before if logFn exists

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -92,13 +92,12 @@ function HttpServer(options) {
 
   var before = options.before ? options.before.slice() : [];
 
-  before.push(function (req, res) {
-    if (options.logFn) {
+  if (options.logFn) {
+    before.push(function (req, res) {
       options.logFn(req, res);
-    }
-
-    res.emit('next');
-  });
+      res.emit('next');
+    });
+  }
 
   if (options.username || options.password) {
     before.push(function (req, res) {


### PR DESCRIPTION
This is a new implementation of #387, but fixed.

Previously, we added a function which would use logFn if it exists.
Since this is all this function does, if logFn does not exist, we don't
need to add the function at all.

This should, in theory, provide a small performance boost as well, since
the operation of checking for logFn doesn't need to be performed on
every request log.
