### PR TITLE
Fix `--ext` with HTML

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -82,13 +82,13 @@ function HttpServer(options) {
   this.showDotfiles = options.showDotfiles;
   this.gzip = options.gzip === true;
   this.brotli = options.brotli === true;
-  this.contentType = options.contentType || 'application/octet-stream';
-
   if (options.ext) {
     this.ext = options.ext === true
       ? 'html'
       : options.ext;
   }
+  this.contentType = options.contentType ||
+    this.ext === 'html' ? 'text/html' : 'application/octet-stream';
 
   var before = options.before ? options.before.slice() : [];
 

--- a/test/fixtures/root/htmlButNot
+++ b/test/fixtures/root/htmlButNot
@@ -1,0 +1,4 @@
+<div>
+  <h1>I am HTML?</h1>
+  <small>yeah i guess</small>
+</div>

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -357,5 +357,27 @@ vows.describe('http-server').addBatch({
     teardown: function (server) {
       server.close();
     }
+  },
+  'When auto-ext is enabled': {
+    topic: function () {
+      var server = httpServer.createServer({
+        root: root,
+        ext: true
+      });
+      server.listen(8085);
+      this.callback(null, server);
+    },
+    'and a file with no extension is requested with default options,': {
+      topic: function () {
+        request('http://127.0.0.1:8085/htmlButNot', this.callback);
+      },
+      'content-type should be text/html': function (res) {
+        assert.equal(res.statusCode, 200);
+        assert.match(res.headers['content-type'], /^text\/html/);
+      }
+    },
+    teardown: function (server) {
+      server.close();
+    }
   }
 }).export(module);


### PR DESCRIPTION
**Please ensure that your pull request fulfills these requirements:**
- [x] The pull request is being made against the `master` branch
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the purpose of this pull request? (bug fix, enhancement, new feature,...)**

Fixes #160 by ensuring that when `--ext` is `true` or `'html'`, and no overriding content-type is set, the content-type is set to `text/html`.
