### PR TITLE
fix named like "%" https://github.com/http-party/http-server/issues/603

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -148,6 +148,31 @@ function HttpServer(options) {
     });
   }
 
+  // fix named like "%" https://github.com/http-party/http-server/issues/603
+  before.push (function(req, res) {
+    function ishex(ch) {
+      return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <='f') || (ch >= 'A' && ch <='F');
+    }
+    var ind = 0 , url = req.url;
+    while ( (ind = url.indexOf('%',ind)) != -1) {
+      if ( (ind + 2) >= url.length ) { // 'test%' -> 'test%25' or 'test%x' -> 'test%25x'
+        url = url.substr(0,ind) + '%25' + url.substr(ind + 1);
+        break;
+      }
+      //check if %xx is hex number ,if not convert % -> %25
+      let ch1 = url.charAt(ind+1) , ch2 = url.charAt(ind+2);
+      if ( !ishex(ch1) || !ishex(ch2)  ) {
+        url = url.substr(0,ind) + '%25' + url.substr(ind + 1);
+        ind += 3;
+      } 
+      else {
+        ind ++;
+      }
+    }
+    req.url = url;
+    res.emit('next');
+  });
+
   before.push(ecstatic({
     root: this.root,
     cache: this.cache,

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -149,24 +149,24 @@ function HttpServer(options) {
   }
 
   // fix named like "%" https://github.com/http-party/http-server/issues/603
-  before.push (function(req, res) {
+  before.push(function (req, res) {
     function ishex(ch) {
-      return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <='f') || (ch >= 'A' && ch <='F');
+      return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
     }
     var ind = 0 , url = req.url;
-    while ( (ind = url.indexOf('%',ind)) != -1) {
-      if ( (ind + 2) >= url.length ) { // 'test%' -> 'test%25' or 'test%x' -> 'test%25x'
+    while ((ind = url.indexOf('%',ind)) !== -1) {
+      if ((ind + 2) >= url.length) { // 'test%' -> 'test%25' or 'test%x' -> 'test%25x'
         url = url.substr(0,ind) + '%25' + url.substr(ind + 1);
         break;
       }
-      //check if %xx is hex number ,if not convert % -> %25
-      let ch1 = url.charAt(ind+1) , ch2 = url.charAt(ind+2);
-      if ( !ishex(ch1) || !ishex(ch2)  ) {
+      // check if %xx is hex number ,if not convert % -> %25
+      var ch1 = url.charAt(ind + 1) , ch2 = url.charAt(ind + 2);
+      if (!ishex(ch1) || !ishex(ch2)) {
         url = url.substr(0,ind) + '%25' + url.substr(ind + 1);
         ind += 3;
-      } 
+      }
       else {
-        ind ++;
+        ind++;
       }
     }
     req.url = url;


### PR DESCRIPTION

**What is the purpose of this pull request? (bug fix, enhancement, new feature,...)**
fix issues 603

**What changes did you make?**
add function to `before` , convert unorthodox "%" -> "%25"