### PR TITLE
fix: pass arguments to server.close

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -206,5 +206,5 @@ HttpServer.prototype.listen = function () {
 };
 
 HttpServer.prototype.close = function () {
-  return this.server.close();
+  return this.server.close.apply(this.server, arguments);
 };


### PR DESCRIPTION
**Please ensure that your pull request fulfills these requirements:**
- [X] The pull request is being made against the `master` branch
- [ ] Tests for the changes have been added (for bug fixes / features)

**What is the purpose of this pull request? (bug fix, enhancement, new feature,...)**

Rather bug fix.

**What changes did you make?**

As for `server.listen`, `server.close` (both for HTTP and HTTPS servers, as returned by union) takes an optional callback which is called on completion or error. This patch adds argument forwarding for `close`.

**Provide some example code that this change will affect, if applicable:**

```js
	const server = createServer({
		root: path.join(__dirname, '..', 'files'),
	});

	await new Promise((resolve) => server.listen(port, resolve));
	
	...

	await new Promise((resolve) => server.close(resolve as any));
```

**Is there anything you'd like reviewers to focus on?**

Well there's no tests, should I somehow write one?

As a side note, `HttpServer.prototype.close` forwards the return value of `this.server.close`, i.e. `this`. But `HttpServer.prototype.listen` does not. I think it should too.

**Please provide testing instructions, if applicable:**

Above code.