### PR TITLE
Bump ecstatic version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -405,6 +405,11 @@
         "supports-color": "^2.0.0"
       }
     },
+    "charset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz",
+      "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg=="
+    },
     "cli": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
@@ -912,15 +917,22 @@
       }
     },
     "ecstatic": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
-      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-4.1.4.tgz",
+      "integrity": "sha512-8E4ZLK4uRuB9pwywGpy/B9vcz4gCp6IY7u4cMbeCINr/fjb1v+0wf0Ae2XlfSnG8xZYnE4uaJBjFkYI0bqcIdw==",
       "requires": {
+        "charset": "^1.0.1",
         "he": "^1.1.1",
-        "mime": "^1.6.0",
+        "mime": "^2.4.1",
         "minimist": "^1.1.0",
-        "url-join": "^2.0.5"
+        "on-finished": "^2.3.0",
+        "url-join": "^4.0.0"
       }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "enabled": {
       "version": "1.0.2",
@@ -1874,9 +1886,9 @@
       "dev": true
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
     },
     "mime-db": {
       "version": "1.44.0",
@@ -2020,6 +2032,14 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
       }
     },
     "once": {
@@ -2684,9 +2704,9 @@
       }
     },
     "url-join": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "user-home": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "basic-auth": "^1.0.3",
     "colors": "^1.4.0",
     "corser": "^2.0.1",
-    "ecstatic": "^3.3.2",
+    "ecstatic": "^4.1.4",
     "http-proxy": "^1.18.0",
     "minimist": "^1.2.5",
     "opener": "^1.5.1",


### PR DESCRIPTION
**Please ensure that your pull request fulfills these requirements:**
- [x] The pull request is being made against the `master` branch
- [ ] Tests for the changes have been added (for bug fixes / features)

**What is the purpose of this pull request? (bug fix, enhancement, new feature,...)**
Attempt to solve #619 

<!--
    Link to the issue this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
-->

**What changes did you make?**

**Provide some example code that this change will affect, if applicable:**

<!-- Paste the example code here: -->

**Is there anything you'd like reviewers to focus on?**
The content tests all fail.  I don't see a difference in the api for ecstatic between major versions.

```
it should serve files from the proxy's root and file content
    ✗ should match content of the served file
        »
        actual expected

        hello, I know nodejitsu
         // /Users/ag69970/code/anthem-ai/http-server/node_modules/vows/lib/assert/macros.js:14
```

**Please provide testing instructions, if applicable:**
I am not familiar with vows or ecstatic.  Someone who is should be able to wrap this up easily.