### PR TITLE
Adding output of server settings on startup

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -166,9 +166,23 @@ function listen(port) {
 
     logger.info([colors.yellow('Starting up http-server, serving '),
       colors.cyan(server.root),
-      ssl ? (colors.yellow(' through') + colors.cyan(' https')) : '',
-      colors.yellow('\nAvailable on:')
+      ssl ? (colors.yellow(' through') + colors.cyan(' https')) : ''
     ].join(''));
+
+    logger.info('before settings')
+
+    logger.info([colors.yellow('\nhttp-server settings: '),
+      ([colors.yellow('CORS: '), argv.cors ? colors.cyan(argv.cors) : colors.red('disabled')].join('')),
+      ([colors.yellow('Cache: '), argv.c ? (argv.c === '-1' ? colors.red('disabled') : colors.cyan(argv.c + ' seconds')) : colors.cyan('3600 seconds')].join('')),
+      ([colors.yellow('Connection Timeout: '), argv.t === '0' ? colors.red('disabled') : (argv.t ? colors.cyan(argv.t + ' seconds') : colors.cyan('120 seconds'))].join('')),
+      ([colors.yellow('Directory Listings: '), argv.d ? colors.red('not visible') : colors.cyan('visible')].join('')),
+      ([colors.yellow('AutoIndex: '), argv.i ? colors.red('not visible') : colors.cyan('visible')].join('')),
+      ([colors.yellow('Serve GZIP Files: '), argv.g || argv.gzip ? colors.cyan('true') : colors.red('false')].join('')),
+      ([colors.yellow('Serve Brotli Files: '), argv.b || argv.brotli ? colors.cyan('true') : colors.red('false')].join('')),
+      ([colors.yellow('Default File Extension: '), argv.e ? colors.cyan(argv.e) : (argv.ext ? colors.cyan(argv.ext) : colors.red('none'))].join(''))
+    ].join('\n'));
+
+    logger.info(colors.yellow('\nAvailable on:'));
 
     if (argv.a && host !== '0.0.0.0') {
       logger.info(('  ' + protocol + canonicalHost + ':' + colors.green(port.toString())));

--- a/bin/http-server
+++ b/bin/http-server
@@ -169,8 +169,6 @@ function listen(port) {
       ssl ? (colors.yellow(' through') + colors.cyan(' https')) : ''
     ].join(''));
 
-    logger.info('before settings')
-
     logger.info([colors.yellow('\nhttp-server settings: '),
       ([colors.yellow('CORS: '), argv.cors ? colors.cyan(argv.cors) : colors.red('disabled')].join('')),
       ([colors.yellow('Cache: '), argv.c ? (argv.c === '-1' ? colors.red('disabled') : colors.cyan(argv.c + ' seconds')) : colors.cyan('3600 seconds')].join('')),


### PR DESCRIPTION
**Please ensure that your pull request fulfills these requirements:**
- [x] The pull request is being made against the `master` branch
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the purpose of this pull request? (bug fix, enhancement, new feature,...)**

Resolves #529 by adding server settings logs to startup.

**What changes did you make?**
Changed the startup function to output logs of common server settings.
No unit tests added, as this is not changing any service functionality.

**Provide some example code that this change will affect, if applicable:**
Affects all server startup commands.

**Is there anything you'd like reviewers to focus on?**
None

**Please provide testing instructions, if applicable:**
Validate that the settings are displayed appropriately.  