### PR TITLE
Allow spaces in the path.

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -30,6 +30,7 @@ path.normalize = function (p) {
   if (caller === 'decodePathname') {
     result = result.replace(/\\/g, '/');
   }
+    result = result.replace("%20", ' ');
   return result;
 };
 


### PR DESCRIPTION
in the `normalize()` function I added a `replace()` statement replacing `%20` with a white space. This should allow spaces on the request path

**Please ensure that your pull request fulfills these requirements:**
- [ X] The pull request is being made against the `master` branch
- [ X] Tests for the changes have been added (for bug fixes / features)

**What is the purpose of this pull request? (bug fix, enhancement, new feature,...)**
Enhancement: now spaces are valid URLs when you normalize the URL

    Link to the issue this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
#660 

**What changes did you make?**
Added a replace statement to the _pathNormalize function

**Provide some example code that this change will affect, if applicable:**

<!-- Paste the example code here: -->

**Is there anything you'd like reviewers to focus on?**

**Please provide testing instructions, if applicable:**
This fix depends on the path being normalized by the refered function before the file is read
