### PR TITLE
Remove hs alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
   "license": "MIT",
   "preferGlobal": true,
   "bin": {
-    "http-server": "./bin/http-server",
-    "hs": "./bin/http-server"
+    "http-server": "./bin/http-server"
   }
 }


### PR DESCRIPTION
The `hs` alias is non-obvious and conflicts with at least one other tool. This is better suited as a user-defined alias, instead of the package setting two for itself.

Fixes #695