### PR TITLE
Add secure false, to allow HTTPS + proxy

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -145,7 +145,8 @@ function HttpServer(options) {
     before.push(function (req, res) {
       proxy.web(req, res, {
         target: options.proxy,
-        changeOrigin: true
+        changeOrigin: true, 
+        secure: false, 
       }, function (err, req, res, target) {
         if (options.logFn) {
           options.logFn(req, res, {


### PR DESCRIPTION
**Please ensure that your pull request fulfills these requirements:**
- [ ] The pull request is being made against the `master` branch
- [ ] Tests for the changes have been added (for bug fixes / features)

**What is the purpose of this pull request? (bug fix, enhancement, new feature,...)**

Allow using the proxy feature with HTTPS

https://github.com/http-party/http-server/issues/719

<!--
    Link to the issue this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
-->

**What changes did you make?**

Set secure flag to false for http-proxy (so it won't try verify self signed certs). 

- Question:  Is the purpose of this library for development only? If not, this probably isn't a good solution. 
- Possibly want a 'verifySslCerts' option, that you can set to false, for this use case. 

**Provide some example code that this change will affect, if applicable:**

Starting a server with: 

```
http-server --proxy https://localhost:8080? ./lib -S -C localhost.crt -K localhost.key -p 8080
```

Where we are using a selfsigned certificate. 


<!-- Paste the example code here: -->

**Is there anything you'd like reviewers to focus on?**

**Please provide testing instructions, if applicable:**

Run the above command, check that you can access the main page at `https://localhost:8080/foobar`

I haven't written any tests yet! Working that out now. 
