### PR TITLE
Added --secure option for self signed SSL proxy support.

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -46,6 +46,7 @@ if (argv.h || argv.help) {
     '               Can also be specified with the env variable NODE_HTTP_SERVER_PASSWORD',
     '',
     '  -S --ssl     Enable https.',
+    '  --secure     Enable certificate validation [true]',
     '  -C --cert    Path to ssl cert file (default: cert.pem).',
     '  -K --key     Path to ssl key file (default: key.pem).',
     '',
@@ -132,6 +133,15 @@ function listen(port) {
     username: argv.username || process.env.NODE_HTTP_SERVER_USERNAME,
     password: argv.password || process.env.NODE_HTTP_SERVER_PASSWORD
   };
+
+  if (argv.secure) {
+    try {
+      options.secure = JSON.parse(argv.secure || true)
+    } catch(error) {
+      logger.info(colors.red('Error: --secure option must be true or false.'));
+      process.exit(1);
+    }
+  }
 
   if (argv.cors) {
     options.cors = true;

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -141,7 +141,7 @@ function HttpServer(options) {
   }));
 
   if (typeof options.proxy === 'string') {
-    var proxy = httpProxy.createProxyServer({});
+    var proxy = httpProxy.createProxyServer({ secure: options.secure });
     before.push(function (req, res) {
       proxy.web(req, res, {
         target: options.proxy,


### PR DESCRIPTION
**Please ensure that your pull request fulfills these requirements:**
- [x] The pull request is being made against the `master` branch
- [ ] Tests for the changes have been added (for bug fixes / features)

**What is the purpose of this pull request? (bug fix, enhancement, new feature,...)**

https://github.com/http-party/http-server/issues/638

Without this change using the --proxy option with https fails with...
Error (404): "unable to verify the first certificate"

**What changes did you make?**

Added command line switch --secure to set secure to false (defaults to true)

**Provide some example code that this change will affect, if applicable:**
```
http-server --proxy https://localhost:8080? ./lib -S -C localhost.crt -K localhost.key -p 8080--secure false
```
