### PR TITLE
Use relative paths in directory listing #661

### DIFF
--- a/lib/core/show-dir/index.js
+++ b/lib/core/show-dir/index.js
@@ -95,7 +95,7 @@ module.exports = (opts) => {
           const writeRow = (file) => {
             // render a row given a [name, stat] tuple
             const isDir = file[1].isDirectory && file[1].isDirectory();
-            let href = `${parsed.pathname.replace(/\/$/, '')}/${encodeURIComponent(file[0])}`;
+            let href = `./${encodeURIComponent(file[0])}`;
 
             // append trailing slash and query for dir entry
             if (isDir) {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -57,8 +57,8 @@ test('http-server main', (t) => {
             requestAsync("http://localhost:8080/").then(res => {
               t.ok(res);
               t.equal(res.statusCode, 200);
-              t.includes(res.body, '/file');
-              t.includes(res.body, '/canYouSeeMe');
+              t.includes(res.body, './file');
+              t.includes(res.body, './canYouSeeMe');
 
               // Custom headers
               t.equal(res.headers['access-control-allow-origin'], '*');

--- a/test/showdir-href-encoding.test.js
+++ b/test/showdir-href-encoding.test.js
@@ -26,7 +26,7 @@ test('url encoding in href', (t) => {
     request.get({
       uri,
     }, (err, res, body) => {
-      t.match(body, /href="\/base\/show-dir%24%24href_encoding%24%24\/aname%2Baplus.txt"/, 'We found the right href');
+      t.match(body, /href="\.\/aname%2Baplus.txt"/, 'We found the right href');
       server.close();
       t.end();
     });

--- a/test/showdir-search-encoding.test.js
+++ b/test/showdir-search-encoding.test.js
@@ -26,7 +26,7 @@ test('directory listing with query string specified', (t) => {
     request.get({
       uri,
     }, (err, res, body) => {
-      t.match(body, /href="\/base\/subdir\/\?a=1&#x26;b=2"/, 'We found the encoded href');
+      t.match(body, /href="\.\/subdir\/\?a=1&#x26;b=2"/, 'We found the encoded href');
       t.notMatch(body, /a=1&b=2/, 'We didn\'t find the unencoded query string value');
       server.close();
       t.end();

--- a/test/showdir-with-spaces.test.js
+++ b/test/showdir-with-spaces.test.js
@@ -26,7 +26,7 @@ test('directory listing when directory name contains spaces', (t) => {
     request.get({
       uri,
     }, (err, res, body) => {
-      t.ok(/href="\/base\/subdir_with%20space\/index.html"/.test(body), 'We found the right href');
+      t.ok(/href="\.\/index.html"/.test(body), 'We found the right href');
       server.close();
       t.end();
     });


### PR DESCRIPTION
Hi there. Thanks for your all continuous work on this! I've fixed #661, please review.

---

**Please ensure that your pull request fulfills these requirements:**
- [x] The pull request is being made against the `master` branch
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the purpose of this pull request? (bug fix, enhancement, new feature,...)**

<!--
    Link to the issue this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
-->

https://github.com/http-party/http-server/issues/661

**What changes did you make?**

Paths in directory listing to be relative

Before: 
![image](https://user-images.githubusercontent.com/34891695/135483758-53776bfd-62e0-42ed-8aea-b88fa38c0059.png)


After:
![image](https://user-images.githubusercontent.com/34891695/135481787-9610f43b-42ba-4a7e-9f56-6c56139eb276.png)


<!-- Paste the example code here: -->

**Is there anything you'd like reviewers to focus on?**

I'm not sure that the tests are fixed properly, so please focus on those.

**Please provide testing instructions, if applicable:**

I tested in following way:

1. Run `npm run test`

There was no error and it says "371 passing".

2. Run `./bin/http-server ./`, check the paths on `http://localhost:8080`

Result image is above.