### PR TITLE
Add option for ssl ca file

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -48,6 +48,7 @@ if (argv.h || argv.help) {
     '  -S --ssl     Enable https.',
     '  -C --cert    Path to ssl cert file (default: cert.pem).',
     '  -K --key     Path to ssl key file (default: key.pem).',
+    '  -A --ca      Path to ssl ca file (default: ca.pem).',
     '',
     '  -r --robots        Respond to /robots.txt [User-agent: *\\nDisallow: /]',
     '  --no-dotfiles      Do not show dotfiles',
@@ -143,7 +144,8 @@ function listen(port) {
   if (ssl) {
     options.https = {
       cert: argv.C || argv.cert || 'cert.pem',
-      key: argv.K || argv.key || 'key.pem'
+      key: argv.K || argv.key || 'key.pem',
+      ca: argv.A || argv.ca || 'ca.pem'
     };
     try {
       fs.lstatSync(options.https.cert);


### PR DESCRIPTION
When running the http-server with SSL enabled, there was no command line option to configure the CA file. I added this option. 

Fixes #155