### PR TITLE
Fix tests EACCESS by finding an open port every time

### DIFF
--- a/test/304.test.js
+++ b/test/304.test.js
@@ -5,161 +5,51 @@ const ecstatic = require('../lib/core');
 const http = require('http');
 const request = require('request');
 const path = require('path');
+const portfinder = require('portfinder');
 
 const root = `${__dirname}/public`;
 const baseDir = 'base';
 
 test('304_not_modified_strong', (t) => {
-  const port = Math.floor((Math.random() * ((1 << 16) - 1e4)) + 1e4);
-  const file = 'a.txt';
+  portfinder.getPort((err, port) => {
+    const file = 'a.txt';
 
-  const server = http.createServer(
-    ecstatic({
-      root,
-      gzip: true,
-      baseDir,
-      autoIndex: true,
-      showDir: true,
-      weakEtags: false,
-      weakCompare: false,
-    })
-  );
+    const server = http.createServer(
+      ecstatic({
+        root,
+        gzip: true,
+        baseDir,
+        autoIndex: true,
+        showDir: true,
+        weakEtags: false,
+        weakCompare: false,
+      })
+    );
 
-  server.listen(port, () => {
-    const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
-
-    request.get({
-      uri,
-      followRedirect: false,
-    }, (err, res) => {
-      if (err) {
-        t.fail(err);
-      }
-
-      t.equal(res.statusCode, 200, 'first request should be a 200');
+    server.listen(port, () => {
+      const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
 
       request.get({
         uri,
         followRedirect: false,
-        headers: { 'if-modified-since': res.headers['last-modified'] },
-      }, (err2, res2) => {
-        if (err2) {
-          t.fail(err2);
+      }, (err, res) => {
+        if (err) {
+          t.fail(err);
         }
 
-        t.equal(res2.statusCode, 304, 'second request should be a 304');
-        t.equal(res2.headers.etag.indexOf('"'), 0, 'should return a strong etag');
-        server.close();
-        t.end();
-      });
-    });
-  });
-});
-
-test('304_not_modified_weak', (t) => {
-  const port = Math.floor((Math.random() * ((1 << 16) - 1e4)) + 1e4);
-  const file = 'b.txt';
-
-  const server = http.createServer(
-    ecstatic({
-      root,
-      gzip: true,
-      baseDir,
-      autoIndex: true,
-      showDir: true,
-      weakCompare: false,
-    })
-  );
-
-  server.listen(port, () => {
-    const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
-    const now = (new Date()).toString();
-
-    request.get({
-      uri,
-      followRedirect: false,
-    }, (err, res) => {
-      if (err) {
-        t.fail(err);
-      }
-
-      t.equal(res.statusCode, 200, 'first request should be a 200');
-
-      request.get({
-        uri,
-        followRedirect: false,
-        headers: { 'if-modified-since': now },
-      }, (err2, res2) => {
-        if (err2) t.fail(err2);
-
-        t.equal(res2.statusCode, 304, 'second request should be a 304');
-        t.equal(res2.headers.etag.indexOf('W/'), 0, 'should return a weak etag');
-        server.close();
-        t.end();
-      });
-    });
-  });
-});
-
-test('304_not_modified_strong_compare', (t) => {
-  const port = Math.floor((Math.random() * ((1 << 16) - 1e4)) + 1e4);
-  const file = 'b.txt';
-
-  const server = http.createServer(
-    ecstatic({
-      root,
-      gzip: true,
-      baseDir,
-      autoIndex: true,
-      showDir: true,
-      weakEtags: false,
-      weakCompare: false,
-    })
-  );
-
-  server.listen(port, () => {
-    const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
-    const now = (new Date()).toString();
-    let etag = null;
-
-    request.get({
-      uri,
-      followRedirect: false,
-    }, (err, res) => {
-      if (err) {
-        t.fail(err);
-      }
-
-      t.equal(res.statusCode, 200, 'first request should be a 200');
-
-      etag = res.headers.etag;
-
-      request.get({
-        uri,
-        followRedirect: false,
-        headers: { 'if-modified-since': now, 'if-none-match': etag },
-      }, (err2, res2) => {
-        if (err2) {
-          t.fail(err2);
-        }
-
-        t.equal(res2.statusCode, 304, 'second request with a strong etag should be 304');
+        t.equal(res.statusCode, 200, 'first request should be a 200');
 
         request.get({
           uri,
           followRedirect: false,
-          headers: { 'if-modified-since': now, 'if-none-match': `W/${etag}` },
-        }, (err3, res3) => {
-          if (err3) {
-            t.fail(err3);
+          headers: { 'if-modified-since': res.headers['last-modified'] },
+        }, (err2, res2) => {
+          if (err2) {
+            t.fail(err2);
           }
 
-          // Note that if both if-modified-since and if-none-match are
-          // provided, the server MUST NOT return a response status of 304
-          // unless doing so is consistent with all of the conditional
-          // header fields in the request
-          // https://www.ietf.org/rfc/rfc2616.txt
-          t.equal(res3.statusCode, 200, 'third request with a weak etag should be 200');
+          t.equal(res2.statusCode, 304, 'second request should be a 304');
+          t.equal(res2.headers.etag.indexOf('"'), 0, 'should return a strong etag');
           server.close();
           t.end();
         });
@@ -168,62 +58,177 @@ test('304_not_modified_strong_compare', (t) => {
   });
 });
 
+test('304_not_modified_weak', (t) => {
+  portfinder.getPort((err, port) => {
+    const file = 'b.txt';
 
-test('304_not_modified_weak_compare', (t) => {
-  const port = Math.floor((Math.random() * ((1 << 16) - 1e4)) + 1e4);
-  const file = 'c.js';
+    const server = http.createServer(
+      ecstatic({
+        root,
+        gzip: true,
+        baseDir,
+        autoIndex: true,
+        showDir: true,
+        weakCompare: false,
+      })
+    );
 
-  const server = http.createServer(
-    ecstatic({
-      root,
-      gzip: true,
-      baseDir,
-      autoIndex: true,
-      showDir: true,
-      weakEtags: false,
-    })
-  );
-
-  server.listen(port, () => {
-    const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
-    const now = (new Date()).toString();
-    let etag = null;
-
-    request.get({
-      uri,
-      followRedirect: false,
-    }, (err, res) => {
-      if (err) {
-        t.fail(err);
-      }
-
-      t.equal(res.statusCode, 200, 'first request should be a 200');
-
-      etag = res.headers.etag;
+    server.listen(port, () => {
+      const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
+      const now = (new Date()).toString();
 
       request.get({
         uri,
         followRedirect: false,
-        headers: { 'if-modified-since': now, 'if-none-match': etag },
-      }, (err2, res2) => {
-        if (err2) {
-          t.fail(err2);
+      }, (err, res) => {
+        if (err) {
+          t.fail(err);
         }
 
-        t.equal(res2.statusCode, 304, 'second request with a strong etag should be 304');
+        t.equal(res.statusCode, 200, 'first request should be a 200');
 
         request.get({
           uri,
           followRedirect: false,
-          headers: { 'if-modified-since': now, 'if-none-match': `W/${etag}` },
-        }, (err3, res3) => {
-          if (err3) {
-            t.fail(err3);
-          }
+          headers: { 'if-modified-since': now },
+        }, (err2, res2) => {
+          if (err2) t.fail(err2);
 
-          t.equal(res3.statusCode, 304, 'third request with a weak etag should be 304');
+          t.equal(res2.statusCode, 304, 'second request should be a 304');
+          t.equal(res2.headers.etag.indexOf('W/'), 0, 'should return a weak etag');
           server.close();
           t.end();
+        });
+      });
+    });
+  });
+});
+
+test('304_not_modified_strong_compare', (t) => {
+  portfinder.getPort((err, port) => {
+    const file = 'b.txt';
+
+    const server = http.createServer(
+      ecstatic({
+        root,
+        gzip: true,
+        baseDir,
+        autoIndex: true,
+        showDir: true,
+        weakEtags: false,
+        weakCompare: false,
+      })
+    );
+
+    server.listen(port, () => {
+      const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
+      const now = (new Date()).toString();
+      let etag = null;
+
+      request.get({
+        uri,
+        followRedirect: false,
+      }, (err, res) => {
+        if (err) {
+          t.fail(err);
+        }
+
+        t.equal(res.statusCode, 200, 'first request should be a 200');
+
+        etag = res.headers.etag;
+
+        request.get({
+          uri,
+          followRedirect: false,
+          headers: { 'if-modified-since': now, 'if-none-match': etag },
+        }, (err2, res2) => {
+          if (err2) {
+            t.fail(err2);
+          }
+
+          t.equal(res2.statusCode, 304, 'second request with a strong etag should be 304');
+
+          request.get({
+            uri,
+            followRedirect: false,
+            headers: { 'if-modified-since': now, 'if-none-match': `W/${etag}` },
+          }, (err3, res3) => {
+            if (err3) {
+              t.fail(err3);
+            }
+
+            // Note that if both if-modified-since and if-none-match are
+            // provided, the server MUST NOT return a response status of 304
+            // unless doing so is consistent with all of the conditional
+            // header fields in the request
+            // https://www.ietf.org/rfc/rfc2616.txt
+            t.equal(res3.statusCode, 200, 'third request with a weak etag should be 200');
+            server.close();
+            t.end();
+          });
+        });
+      });
+    });
+  });
+});
+
+
+test('304_not_modified_weak_compare', (t) => {
+  portfinder.getPort((err, port) => {
+    const file = 'c.js';
+
+    const server = http.createServer(
+      ecstatic({
+        root,
+        gzip: true,
+        baseDir,
+        autoIndex: true,
+        showDir: true,
+        weakEtags: false,
+      })
+    );
+
+    server.listen(port, () => {
+      const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
+      const now = (new Date()).toString();
+      let etag = null;
+
+      request.get({
+        uri,
+        followRedirect: false,
+      }, (err, res) => {
+        if (err) {
+          t.fail(err);
+        }
+
+        t.equal(res.statusCode, 200, 'first request should be a 200');
+
+        etag = res.headers.etag;
+
+        request.get({
+          uri,
+          followRedirect: false,
+          headers: { 'if-modified-since': now, 'if-none-match': etag },
+        }, (err2, res2) => {
+          if (err2) {
+            t.fail(err2);
+          }
+
+          t.equal(res2.statusCode, 304, 'second request with a strong etag should be 304');
+
+          request.get({
+            uri,
+            followRedirect: false,
+            headers: { 'if-modified-since': now, 'if-none-match': `W/${etag}` },
+          }, (err3, res3) => {
+            if (err3) {
+              t.fail(err3);
+            }
+
+            t.equal(res3.statusCode, 304, 'third request with a weak etag should be 304');
+            server.close();
+            t.end();
+          });
         });
       });
     });

--- a/test/core-error.test.js
+++ b/test/core-error.test.js
@@ -15,57 +15,58 @@ mkdirp.sync(`${root}/emptyDir`);
 const cases = require('./fixtures/common-cases-error');
 
 test('core', (t) => {
-  const filenames = Object.keys(cases);
-  const port = Math.floor((Math.random() * ((1 << 16) - 1e4)) + 1e4);
+  require('portfinder').getPort((err, port) => {
+    const filenames = Object.keys(cases);
 
-  const server = http.createServer(
-    ecstatic({
-      root,
-      gzip: true,
-      baseDir,
-      autoIndex: true,
-      showDir: true,
-      handleError: false,
-    })
-  );
+    const server = http.createServer(
+      ecstatic({
+        root,
+        gzip: true,
+        baseDir,
+        autoIndex: true,
+        showDir: true,
+        handleError: false,
+      })
+    );
 
-  server.listen(port, () => {
-    let pending = filenames.length;
-    filenames.forEach((file) => {
-      const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
-      const headers = cases[file].headers || {};
+    server.listen(port, () => {
+      let pending = filenames.length;
+      filenames.forEach((file) => {
+        const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
+        const headers = cases[file].headers || {};
 
-      request.get({
-        uri,
-        followRedirect: false,
-        headers,
-      }, (err, res, body) => {
-        if (err) {
-          t.fail(err);
-        }
-        const r = cases[file];
-        t.equal(res.statusCode, r.code, `status code for \`${file}\``);
+        request.get({
+          uri,
+          followRedirect: false,
+          headers,
+        }, (err, res, body) => {
+          if (err) {
+            t.fail(err);
+          }
+          const r = cases[file];
+          t.equal(res.statusCode, r.code, `status code for \`${file}\``);
 
-        if (r.type !== undefined) {
-          t.equal(
-            res.headers['content-type'].split(';')[0], r.type,
-            `content-type for \`${file}\``
-          );
-        }
+          if (r.type !== undefined) {
+            t.equal(
+              res.headers['content-type'].split(';')[0], r.type,
+              `content-type for \`${file}\``
+            );
+          }
 
-        if (r.body !== undefined) {
-          t.equal(body, r.body, `body for \`${file}\``);
-        }
+          if (r.body !== undefined) {
+            t.equal(body, r.body, `body for \`${file}\``);
+          }
 
-        if (r.location !== undefined) {
-          t.equal(res.headers.location, path.join('/', baseDir, r.location), `location for \`${file}\``);
-        }
+          if (r.location !== undefined) {
+            t.equal(res.headers.location, path.join('/', baseDir, r.location), `location for \`${file}\``);
+          }
 
-        pending -= 1;
-        if (pending === 0) {
-          server.close();
-          t.end();
-        }
+          pending -= 1;
+          if (pending === 0) {
+            server.close();
+            t.end();
+          }
+        });
       });
     });
   });

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -16,58 +16,59 @@ mkdirp.sync(`${root}/emptyDir`);
 const cases = require('./fixtures/common-cases');
 
 test('core', (t) => {
-  const filenames = Object.keys(cases);
-  const port = Math.floor((Math.random() * ((1 << 16) - 1e4)) + 1e4);
+  require('portfinder').getPort((err, port) => {
+    const filenames = Object.keys(cases);
 
-  const server = http.createServer(
-    ecstatic({
-      root,
-      gzip: true,
-      baseDir,
-      autoIndex: true,
-      showDir: true,
-      defaultExt: 'html',
-      handleError: true,
-    })
-  );
+    const server = http.createServer(
+      ecstatic({
+        root,
+        gzip: true,
+        baseDir,
+        autoIndex: true,
+        showDir: true,
+        defaultExt: 'html',
+        handleError: true,
+      })
+    );
 
-  server.listen(port, () => {
-    let pending = filenames.length;
-    filenames.forEach((file) => {
-      const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
-      const headers = cases[file].headers || {};
+    server.listen(port, () => {
+      let pending = filenames.length;
+      filenames.forEach((file) => {
+        const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
+        const headers = cases[file].headers || {};
 
-      request.get({
-        uri,
-        followRedirect: false,
-        headers,
-      }, (err, res, body) => {
-        if (err) {
-          t.fail(err);
-        }
-        const r = cases[file];
-        t.equal(res.statusCode, r.code, `status code for \`${file}\``);
+        request.get({
+          uri,
+          followRedirect: false,
+          headers,
+        }, (err, res, body) => {
+          if (err) {
+            t.fail(err);
+          }
+          const r = cases[file];
+          t.equal(res.statusCode, r.code, `status code for \`${file}\``);
 
-        if (r.type !== undefined) {
-          t.equal(
-            res.headers['content-type'].split(';')[0], r.type,
-            `content-type for \`${file}\``
-          );
-        }
+          if (r.type !== undefined) {
+            t.equal(
+              res.headers['content-type'].split(';')[0], r.type,
+              `content-type for \`${file}\``
+            );
+          }
 
-        if (r.body !== undefined) {
-          t.equal(eol.lf(body), r.body, `body for \`${file}\``);
-        }
+          if (r.body !== undefined) {
+            t.equal(eol.lf(body), r.body, `body for \`${file}\``);
+          }
 
-        if (r.location !== undefined) {
-          t.equal(path.normalize(res.headers.location), path.join('/', baseDir, r.location), `location for \`${file}\``);
-        }
+          if (r.location !== undefined) {
+            t.equal(path.normalize(res.headers.location), path.join('/', baseDir, r.location), `location for \`${file}\``);
+          }
 
-        pending -= 1;
-        if (pending === 0) {
-          server.close();
-          t.end();
-        }
+          pending -= 1;
+          if (pending === 0) {
+            server.close();
+            t.end();
+          }
+        });
       });
     });
   });

--- a/test/express.test.js
+++ b/test/express.test.js
@@ -17,59 +17,60 @@ mkdirp.sync(`${root}/emptyDir`);
 const cases = require('./fixtures/common-cases');
 
 test('express', (t) => {
-  const filenames = Object.keys(cases);
-  const port = Math.floor((Math.random() * ((1 << 16) - 1e4)) + 1e4);
+  require('portfinder').getPort((err, port) => {
+    const filenames = Object.keys(cases);
 
-  const app = express();
+    const app = express();
 
-  app.use(ecstatic({
-    root,
-    gzip: true,
-    baseDir,
-    autoIndex: true,
-    showDir: true,
-    defaultExt: 'html',
-    cache: 'no-cache',
-    handleError: true,
-  }));
+    app.use(ecstatic({
+      root,
+      gzip: true,
+      baseDir,
+      autoIndex: true,
+      showDir: true,
+      defaultExt: 'html',
+      cache: 'no-cache',
+      handleError: true,
+    }));
 
-  const server = http.createServer(app);
+    const server = http.createServer(app);
 
-  server.listen(port, () => {
-    let pending = filenames.length;
-    filenames.forEach((file) => {
-      const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
-      const headers = cases[file].headers || {};
+    server.listen(port, () => {
+      let pending = filenames.length;
+      filenames.forEach((file) => {
+        const uri = `http://localhost:${port}${path.join('/', baseDir, file)}`;
+        const headers = cases[file].headers || {};
 
-      request.get({
-        uri,
-        followRedirect: false,
-        headers,
-      }, (err, res, body) => {
-        if (err) t.fail(err);
-        const r = cases[file];
-        t.equal(res.statusCode, r.code, `status code for \`${file}\``);
+        request.get({
+          uri,
+          followRedirect: false,
+          headers,
+        }, (err, res, body) => {
+          if (err) t.fail(err);
+          const r = cases[file];
+          t.equal(res.statusCode, r.code, `status code for \`${file}\``);
 
-        if (r.code === 200) {
-          t.equal(res.headers['cache-control'], 'no-cache', `cache control for \`${file}\``);
-        }
+          if (r.code === 200) {
+            t.equal(res.headers['cache-control'], 'no-cache', `cache control for \`${file}\``);
+          }
 
-        if (r.type !== undefined) {
-          t.equal(
-            res.headers['content-type'].split(';')[0], r.type,
-            `content-type for \`${file}\``
-          );
-        }
+          if (r.type !== undefined) {
+            t.equal(
+              res.headers['content-type'].split(';')[0], r.type,
+              `content-type for \`${file}\``
+            );
+          }
 
-        if (r.body !== undefined) {
-          t.equal(eol.lf(body), r.body, `body for \`${file}\``);
-        }
+          if (r.body !== undefined) {
+            t.equal(eol.lf(body), r.body, `body for \`${file}\``);
+          }
 
-        pending -= 1;
-        if (pending === 0) {
-          server.close();
-          t.end();
-        }
+          pending -= 1;
+          if (pending === 0) {
+            server.close();
+            t.end();
+          }
+        });
       });
     });
   });

--- a/test/showdir-href-encoding.test.js
+++ b/test/showdir-href-encoding.test.js
@@ -10,25 +10,26 @@ const root = `${__dirname}/public`;
 const baseDir = 'base';
 
 test('url encoding in href', (t) => {
-  const port = Math.floor((Math.random() * ((1 << 16) - 1e4)) + 1e4);
-  const uri = `http://localhost:${port}${path.join('/', baseDir, 'show-dir%24%24href_encoding%24%24')}`;
+  require('portfinder').getPort((err, port) => {
+    const uri = `http://localhost:${port}${path.join('/', baseDir, 'show-dir%24%24href_encoding%24%24')}`;
 
-  const server = http.createServer(
-    ecstatic({
-      root,
-      baseDir,
-      showDir: true,
-      autoIndex: false,
-    })
-  );
+    const server = http.createServer(
+      ecstatic({
+        root,
+        baseDir,
+        showDir: true,
+        autoIndex: false,
+      })
+    );
 
-  server.listen(port, () => {
-    request.get({
-      uri,
-    }, (err, res, body) => {
-      t.match(body, /href="\.\/aname%2Baplus.txt"/, 'We found the right href');
-      server.close();
-      t.end();
+    server.listen(port, () => {
+      request.get({
+        uri,
+      }, (err, res, body) => {
+        t.match(body, /href="\.\/aname%2Baplus.txt"/, 'We found the right href');
+        server.close();
+        t.end();
+      });
     });
   });
 });

--- a/test/showdir-pathname-encoding.test.js
+++ b/test/showdir-pathname-encoding.test.js
@@ -24,27 +24,26 @@ test('create test directory', (t) => {
 });
 
 test('directory listing with pathname including HTML characters', (t) => {
-  const port = Math.floor((Math.random() * ((1 << 16) - 1e4)) + 1e4);
+  require('portfinder').getPort((err, port) => {
+    const uri = `http://localhost:${port}${path.join('/', baseDir, '/%3Cdir%3E')}`;
+    const server = http.createServer(
+      ecstatic({
+        root,
+        baseDir,
+        showDir: true,
+        autoIndex: false,
+      })
+    );
 
-  const uri = `http://localhost:${port}${path.join('/', baseDir, '/%3Cdir%3E')}`;
-
-  const server = http.createServer(
-    ecstatic({
-      root,
-      baseDir,
-      showDir: true,
-      autoIndex: false,
-    })
-  );
-
-  server.listen(port, () => {
-    request.get({
-      uri,
-    }, (err, res, body) => {
-      t.notMatch(body, /<dir>/, 'We didn\'t find the unencoded pathname');
-      t.match(body, /&#x3C;dir&#x3E;/, 'We found the encoded pathname');
-      server.close();
-      t.end();
+    server.listen(port, () => {
+      request.get({
+        uri,
+      }, (err, res, body) => {
+        t.notMatch(body, /<dir>/, 'We didn\'t find the unencoded pathname');
+        t.match(body, /&#x3C;dir&#x3E;/, 'We found the encoded pathname');
+        server.close();
+        t.end();
+      });
     });
   });
 });

--- a/test/showdir-search-encoding.test.js
+++ b/test/showdir-search-encoding.test.js
@@ -10,26 +10,27 @@ const root = `${__dirname}/public`;
 const baseDir = 'base';
 
 test('directory listing with query string specified', (t) => {
-  const port = Math.floor((Math.random() * ((1 << 16) - 1e4)) + 1e4);
-  const uri = `http://localhost:${port}${path.join('/', baseDir, '?a=1&b=2')}`;
+  require('portfinder').getPort((err, port) => {
+    const uri = `http://localhost:${port}${path.join('/', baseDir, '?a=1&b=2')}`;
 
-  const server = http.createServer(
-    ecstatic({
-      root,
-      baseDir,
-      showDir: true,
-      autoIndex: false,
-    })
-  );
+    const server = http.createServer(
+      ecstatic({
+        root,
+        baseDir,
+        showDir: true,
+        autoIndex: false,
+      })
+    );
 
-  server.listen(port, () => {
-    request.get({
-      uri,
-    }, (err, res, body) => {
-      t.match(body, /href="\.\/subdir\/\?a=1&#x26;b=2"/, 'We found the encoded href');
-      t.notMatch(body, /a=1&b=2/, 'We didn\'t find the unencoded query string value');
-      server.close();
-      t.end();
+    server.listen(port, () => {
+      request.get({
+        uri,
+      }, (err, res, body) => {
+        t.match(body, /href="\.\/subdir\/\?a=1&#x26;b=2"/, 'We found the encoded href');
+        t.notMatch(body, /a=1&b=2/, 'We didn\'t find the unencoded query string value');
+        server.close();
+        t.end();
+      });
     });
   });
 });

--- a/test/showdir-with-spaces.test.js
+++ b/test/showdir-with-spaces.test.js
@@ -10,25 +10,26 @@ const root = `${__dirname}/public`;
 const baseDir = 'base';
 
 test('directory listing when directory name contains spaces', (t) => {
-  const port = Math.floor((Math.random() * ((1 << 16) - 1e4)) + 1e4);
-  const uri = `http://localhost:${port}${path.join('/', baseDir, 'subdir_with%20space')}`;
+  require('portfinder').getPort((err, port) => {
+    const uri = `http://localhost:${port}${path.join('/', baseDir, 'subdir_with%20space')}`;
 
-  const server = http.createServer(
-    ecstatic({
-      root,
-      baseDir,
-      showDir: true,
-      autoIndex: false,
-    })
-  );
+    const server = http.createServer(
+      ecstatic({
+        root,
+        baseDir,
+        showDir: true,
+        autoIndex: false,
+      })
+    );
 
-  server.listen(port, () => {
-    request.get({
-      uri,
-    }, (err, res, body) => {
-      t.ok(/href="\.\/index.html"/.test(body), 'We found the right href');
-      server.close();
-      t.end();
+    server.listen(port, () => {
+      request.get({
+        uri,
+      }, (err, res, body) => {
+        t.ok(/href="\.\/index.html"/.test(body), 'We found the right href');
+        server.close();
+        t.end();
+      });
     });
   });
 });


### PR DESCRIPTION
Replaces tests which used a random port with `portfinder` to grab an open port every time.

fixes #723