### PR TITLE
Fixes --proxy without a protocol throwing an uncaught error

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -140,6 +140,13 @@ function listen(port) {
     }
   }
 
+  if (proxy) {
+    if (!proxy.startsWith('http://') && !proxy.startsWith('https://')) {
+      logger.info(colors.red('Error: Proxy must specify a protocol'));
+      process.exit(1);
+    }
+  }
+
   if (ssl) {
     options.https = {
       cert: argv.C || argv.cert || 'cert.pem',

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -122,3 +122,16 @@ test('setting mimeTypes via cli - directly', (t) => {
     });
   });
 });
+
+test('--proxy requires you to specify a protocol', (t) => {
+  t.plan(1);
+  
+  const options = ['.', '--proxy', 'google.com'];
+  const ecstatic = startEcstatic(options);
+
+  tearDown(ecstatic, t);
+
+  ecstatic.on('exit', (code) => {
+    t.equal(code, 1);
+  });
+});


### PR DESCRIPTION
This fixes the issue where the --proxy would throw an uncaught error when used without specifying a protocol. The fix is having the server not allow you to use --proxy without specifying a valid protocol.

Fixes #451