### PR TITLE
fix crash on redirect with formfeed in URL

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -31,6 +31,11 @@ function decodePathname(pathname) {
       ? normalized.replace(/\\/g, '/') : normalized;
 }
 
+const nonUrlSafeCharsRgx = /[\x00-\x1F\x20\x7F-\uFFFF]+/g;
+function ensureUriEncoded(text) {
+  return text
+  return String(text).replace(nonUrlSafeCharsRgx, encodeURIComponent);
+}
 
 // Check to see if we should try to compress a file with gzip.
 function shouldCompressGzip(req) {
@@ -161,7 +166,8 @@ module.exports = function createMiddleware(_dir, _options) {
       if (opts.weakCompare && clientEtag !== serverEtag
         && clientEtag !== `W/${serverEtag}` && `W/${clientEtag}` !== serverEtag) {
         return false;
-      } else if (!opts.weakCompare && (clientEtag !== serverEtag || clientEtag.indexOf('W/') === 0)) {
+      }
+      if (!opts.weakCompare && (clientEtag !== serverEtag || clientEtag.indexOf('W/') === 0)) {
         return false;
       }
     }
@@ -340,8 +346,10 @@ module.exports = function createMiddleware(_dir, _options) {
             }, res, next);
           } else {
             // Try to serve default ./404.html
+            const rawUrl = (handleError ? `/${path.join(baseDir, `404.${defaultExt}`)}` : req.url);
+            const encodedUrl = ensureUriEncoded(rawUrl);
             middleware({
-              url: (handleError ? `/${path.join(baseDir, `404.${defaultExt}`)}` : req.url),
+              url: encodedUrl,
               headers: req.headers,
               statusCode: 404,
             }, res, next);
@@ -359,7 +367,10 @@ module.exports = function createMiddleware(_dir, _options) {
           if (!pathname.match(/\/$/)) {
             res.statusCode = 302;
             const q = parsed.query ? `?${parsed.query}` : '';
-            res.setHeader('location', `${parsed.pathname}/${q}`);
+            res.setHeader(
+              'location',
+              ensureUriEncoded(`${parsed.pathname}/${q}`)
+            );
             res.end();
             return;
           }

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -87,6 +87,19 @@ test('http-server main', (t) => {
                   .indexOf('X-Test') >= 0, 204);
             }).catch(err => t.fail(err.toString())),
 
+            t.test(
+              "Regression: don't crash on control characters in query strings",
+              {},
+              (t) => {
+                requestAsync({
+                  uri: encodeURI('http://localhost:8080/file?\x0cfoo'),
+                }).then(res => {
+                  t.equal(res.statusCode, 200);
+                }).catch(err => t.fail(err.toString()))
+                  .finally(() => t.end());
+              }
+            ),
+
             // Light compression testing. Heavier compression tests exist in
             // compression.test.js
             requestAsync({


### PR DESCRIPTION
Fixes a vulnerability inherited from ecstatic, reported in CVE-2019-10775.

Changes are based on jfhbrook/node-ecstatic#266

<!--- Describe the changes here. --->

##### Relevant issues

<!--
    Link to the issue(s) this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
    
    If your PR fixes multiple issues, list them individually like "Fixes #xx1, fixes #xx2, fixes #xx3". This is a quirk of how GitHub links issues.
-->

##### Contributor checklist

- [x] Provide tests for the changes (unless documentation-only)
- [x] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [x] Assign a version triage tag
- [x] Approve tests if applicable
