### PR TITLE
Don't crash when file path errors

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -28,7 +28,7 @@ function decodePathname(pathname) {
     return piece;
   }).join('/'));
   return process.platform === 'win32'
-      ? normalized.replace(/\\/g, '/') : normalized;
+    ? normalized.replace(/\\/g, '/') : normalized;
 }
 
 const nonUrlSafeCharsRgx = /[\x00-\x1F\x20\x7F-\uFFFF]+/g;
@@ -43,9 +43,9 @@ function shouldCompressGzip(req) {
 
   return headers && headers['accept-encoding'] &&
     headers['accept-encoding']
-      .split(',')
-      .some(el => ['*', 'compress', 'gzip', 'deflate'].indexOf(el.trim()) !== -1)
-    ;
+    .split(',')
+    .some(el => ['*', 'compress', 'gzip', 'deflate'].indexOf(el.trim()) !== -1)
+  ;
 }
 
 function shouldCompressBrotli(req) {
@@ -164,7 +164,7 @@ module.exports = function createMiddleware(_dir, _options) {
       // Do a strong or weak etag comparison based on setting
       // https://www.ietf.org/rfc/rfc2616.txt Section 13.3.3
       if (opts.weakCompare && clientEtag !== serverEtag
-        && clientEtag !== `W/${serverEtag}` && `W/${clientEtag}` !== serverEtag) {
+          && clientEtag !== `W/${serverEtag}` && `W/${clientEtag}` !== serverEtag) {
         return false;
       }
       if (!opts.weakCompare && (clientEtag !== serverEtag || clientEtag.indexOf('W/') === 0)) {
@@ -330,79 +330,83 @@ module.exports = function createMiddleware(_dir, _options) {
 
 
     function statFile() {
-      fs.stat(file, (err, stat) => {
-        if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
-          if (req.statusCode === 404) {
-            // This means we're already trying ./404.html and can not find it.
-            // So send plain text response with 404 status code
-            status[404](res, next);
-          } else if (!path.extname(parsed.pathname).length && defaultExt) {
-            // If there is no file extension in the path and we have a default
-            // extension try filename and default extension combination before rendering 404.html.
-            middleware({
-              url: `${parsed.pathname}.${defaultExt}${(parsed.search) ? parsed.search : ''}`,
-              headers: req.headers,
-            }, res, next);
+      try {
+        fs.stat(file, (err, stat) => {
+          if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
+            if (req.statusCode === 404) {
+              // This means we're already trying ./404.html and can not find it.
+              // So send plain text response with 404 status code
+              status[404](res, next);
+            } else if (!path.extname(parsed.pathname).length && defaultExt) {
+              // If there is no file extension in the path and we have a default
+              // extension try filename and default extension combination before rendering 404.html.
+              middleware({
+                url: `${parsed.pathname}.${defaultExt}${(parsed.search) ? parsed.search : ''}`,
+                headers: req.headers,
+              }, res, next);
+            } else {
+              // Try to serve default ./404.html
+              const rawUrl = (handleError ? `/${path.join(baseDir, `404.${defaultExt}`)}` : req.url);
+              const encodedUrl = ensureUriEncoded(rawUrl);
+              middleware({
+                url: encodedUrl,
+                headers: req.headers,
+                statusCode: 404,
+              }, res, next);
+            }
+          } else if (err) {
+            status[500](res, next, { error: err });
+          } else if (stat.isDirectory()) {
+            if (!autoIndex && !opts.showDir) {
+              status[404](res, next);
+              return;
+            }
+
+
+            // 302 to / if necessary
+            if (!pathname.match(/\/$/)) {
+              res.statusCode = 302;
+              const q = parsed.query ? `?${parsed.query}` : '';
+              res.setHeader(
+                'location',
+                ensureUriEncoded(`${parsed.pathname}/${q}`)
+              );
+              res.end();
+              return;
+            }
+
+            if (autoIndex) {
+              middleware({
+                url: urlJoin(
+                  encodeURIComponent(pathname),
+                  `/index.${defaultExt}`
+                ),
+                headers: req.headers,
+              }, res, (autoIndexError) => {
+                if (autoIndexError) {
+                  status[500](res, next, { error: autoIndexError });
+                  return;
+                }
+                if (opts.showDir) {
+                  showDir(opts, stat)(req, res);
+                  return;
+                }
+
+                status[403](res, next);
+              });
+              return;
+            }
+
+            if (opts.showDir) {
+              showDir(opts, stat)(req, res);
+            }
           } else {
-            // Try to serve default ./404.html
-            const rawUrl = (handleError ? `/${path.join(baseDir, `404.${defaultExt}`)}` : req.url);
-            const encodedUrl = ensureUriEncoded(rawUrl);
-            middleware({
-              url: encodedUrl,
-              headers: req.headers,
-              statusCode: 404,
-            }, res, next);
+            serve(stat);
           }
-        } else if (err) {
-          status[500](res, next, { error: err });
-        } else if (stat.isDirectory()) {
-          if (!autoIndex && !opts.showDir) {
-            status[404](res, next);
-            return;
-          }
-
-
-          // 302 to / if necessary
-          if (!pathname.match(/\/$/)) {
-            res.statusCode = 302;
-            const q = parsed.query ? `?${parsed.query}` : '';
-            res.setHeader(
-              'location',
-              ensureUriEncoded(`${parsed.pathname}/${q}`)
-            );
-            res.end();
-            return;
-          }
-
-          if (autoIndex) {
-            middleware({
-              url: urlJoin(
-                encodeURIComponent(pathname),
-                `/index.${defaultExt}`
-              ),
-              headers: req.headers,
-            }, res, (autoIndexError) => {
-              if (autoIndexError) {
-                status[500](res, next, { error: autoIndexError });
-                return;
-              }
-              if (opts.showDir) {
-                showDir(opts, stat)(req, res);
-                return;
-              }
-
-              status[403](res, next);
-            });
-            return;
-          }
-
-          if (opts.showDir) {
-            showDir(opts, stat)(req, res);
-          }
-        } else {
-          serve(stat);
-        }
-      });
+        });
+      } catch (err) {
+        status[500](res, next, { error: err.message });
+      }
     }
 
     function isTextFile(mimeType) {
@@ -411,34 +415,42 @@ module.exports = function createMiddleware(_dir, _options) {
 
     // serve gzip file if exists and is valid
     function tryServeWithGzip() {
-      fs.stat(gzippedFile, (err, stat) => {
-        if (!err && stat.isFile()) {
-          hasGzipId12(gzippedFile, (gzipErr, isGzip) => {
-            if (!gzipErr && isGzip) {
-              file = gzippedFile;
-              serve(stat);
-            } else {
-              statFile();
-            }
-          });
-        } else {
-          statFile();
-        }
-      });
+      try {
+        fs.stat(gzippedFile, (err, stat) => {
+          if (!err && stat.isFile()) {
+            hasGzipId12(gzippedFile, (gzipErr, isGzip) => {
+              if (!gzipErr && isGzip) {
+                file = gzippedFile;
+                serve(stat);
+              } else {
+                statFile();
+              }
+            });
+          } else {
+            statFile();
+          }
+        });
+      } catch (err) {
+        status[500](res, next, { error: err.message });
+      }
     }
 
     // serve brotli file if exists, otherwise try gzip
     function tryServeWithBrotli(shouldTryGzip) {
-      fs.stat(brotliFile, (err, stat) => {
-        if (!err && stat.isFile()) {
-          file = brotliFile;
-          serve(stat);
-        } else if (shouldTryGzip) {
-          tryServeWithGzip();
-        } else {
-          statFile();
-        }
-      });
+      try {
+        fs.stat(brotliFile, (err, stat) => {
+          if (!err && stat.isFile()) {
+            file = brotliFile;
+            serve(stat);
+          } else if (shouldTryGzip) {
+            tryServeWithGzip();
+          } else {
+            statFile();
+          }
+        });
+      } catch (err) {
+        status[500](res, next, { error: err.message });
+      }
     }
 
     const shouldTryBrotli = opts.brotli && shouldCompressBrotli(req);


### PR DESCRIPTION
When an invalid file path, such as one that contains a null byte (0x00), report this as an error without crashing.

##### Relevant issues

<!--
    Link to the issue(s) this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
    
    If your PR fixes multiple issues, list them individually like "Fixes #xx1, fixes #xx2, fixes #xx3". This is a quirk of how GitHub links issues.
-->
Fixes #502

##### Contributor checklist

- [x] Provide tests for the changes (unless documentation-only)
- [x] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [x] Assign a version triage tag
- [x] Approve tests if applicable
