### PR TITLE
Mirror Origin header back in CORS response

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -99,15 +99,24 @@ function HttpServer(options) {
   }
 
   if (options.cors) {
-    this.headers['Access-Control-Allow-Origin'] = '*';
     this.headers['Access-Control-Allow-Headers'] = 'Origin, X-Requested-With, Content-Type, Accept, Range';
     if (options.corsHeaders) {
       options.corsHeaders.split(/\s*,\s*/)
         .forEach(function (h) { this.headers['Access-Control-Allow-Headers'] += ', ' + h; }, this);
     }
-    before.push(corser.create(options.corsHeaders ? {
-      requestHeaders: this.headers['Access-Control-Allow-Headers'].split(/\s*,\s*/)
-    } : null));
+    var corserOptions = {
+      // For CORS, we need to mirror the Origin instead of sending the wildcard `*`.
+      // Because, some browsers don't permit wildcards on certain request types.
+      // https://github.com/http-party/http-server/issues/729
+      // corser's `origins` option mirrors the Origin back in Access-Control-Allow-Origin.
+      origins: function (_origin, callback) {
+        callback(null, true);
+      }
+    };
+    if (options.corsHeaders) {
+      corserOptions.requestHeaders = this.headers['Access-Control-Allow-Headers'].split(/\s*,\s*/);
+    }
+    before.push(corser.create(corserOptions));
   }
 
   if (options.robots) {

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -78,10 +78,13 @@ test('cors set to true', (t) => {
   httpServer.listen(() => {
     const port = httpServer.address().port;
     const uri = `http://localhost:${port}/subdir/index.html`;
-    request.get({ uri }, (err, res) => {
+    request.get({
+      uri,
+      headers: {'Origin': 'https://abc.example.com:7777'},
+    }, (err, res) => {
       t.ifError(err);
       t.equal(res.statusCode, 200);
-      t.equal(res.headers['access-control-allow-origin'], '*');
+      t.equal(res.headers['access-control-allow-origin'], 'https://abc.example.com:7777');
       t.equal(res.headers['access-control-allow-headers'], 'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since');
     });
   });
@@ -105,10 +108,13 @@ test('CORS set to true', (t) => {
   httpServer.listen(() => {
     const port = httpServer.address().port;
     const uri = `http://localhost:${port}/subdir/index.html`;
-    request.get({ uri }, (err, res) => {
+    request.get({
+      uri,
+      headers: {'Origin': 'https://abc.example.com:7777'},
+    }, (err, res) => {
       t.ifError(err);
       t.equal(res.statusCode, 200);
-      t.equal(res.headers['access-control-allow-origin'], '*');
+      t.equal(res.headers['access-control-allow-origin'], 'https://abc.example.com:7777');
       t.equal(res.headers['access-control-allow-headers'], 'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since');
     });
   });


### PR DESCRIPTION
Use `corser`'s `origins` option to handle the `access-control-allow-origin` header. Passing a true function will make `corser` mirror the Origin header like we want.

I was not able to run the tests because my port `8080` is not available. I tried to make the tests configurable but I couldn't get the `cors.test.js` server to use the right port with the `httpServer.listen()` calls. Hopefully the tests pass, but if they don't, I'll need some help debugging/rewriting the tests.

##### Relevant issues

Resolves https://github.com/http-party/http-server/issues/729


##### Contributor checklist

- [x] Provide tests for the changes (unless documentation-only)
- [ ] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
