### PR TITLE
Transfrom the buffer to string

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -243,7 +243,7 @@ module.exports = function createMiddleware(_dir, _options) {
             defaultEncoding: 'UTF-8'
           });
           contentType += `; charset=${sniffedEncoding}`;
-          stream = Readable.from(bytes)
+          stream = Readable.from(bytes.toString())
         } else {
           // Assume text types are utf8
           contentType += '; charset=UTF-8';

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -5,7 +5,6 @@
 const path = require('path');
 const fs = require('fs');
 const url = require('url');
-const { Readable } = require('stream');
 const buffer = require('buffer');
 const mime = require('mime');
 const urlJoin = require('url-join');
@@ -235,7 +234,6 @@ module.exports = function createMiddleware(_dir, _options) {
       const lastModified = (new Date(stat.mtime)).toUTCString();
       const etag = generateEtag(stat, weakEtags);
       let cacheControl = cache;
-      let stream = null;
       if (contentType && isTextFile(contentType)) {
         if (stat.size < buffer.constants.MAX_LENGTH) {
           const bytes = fs.readFileSync(file);
@@ -243,7 +241,6 @@ module.exports = function createMiddleware(_dir, _options) {
             defaultEncoding: 'UTF-8'
           });
           contentType += `; charset=${sniffedEncoding}`;
-          stream = Readable.from(bytes.toString())
         } else {
           // Assume text types are utf8
           contentType += '; charset=UTF-8';
@@ -329,10 +326,8 @@ module.exports = function createMiddleware(_dir, _options) {
         return;
       }
 
-      // stream may already have been assigned during encoding sniffing.
-      if (stream === null) {
-        stream = fs.createReadStream(file);
-      }
+      // create a clean stream using 'createReadStream'
+      const stream = fs.createReadStream(file);
 
       stream.pipe(res);
       stream.on('error', (err) => {


### PR DESCRIPTION
<!--- Describe the changes here. --->

##### Relevant issues

#756 
#634
<!--
    Link to the issue(s) this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
    
    If your PR fixes multiple issues, list them individually like "Fixes #xx1, fixes #xx2, fixes #xx3". This is a quirk of how GitHub links issues.
-->

The ̀stream` is piped in `res`. Next the stream generate an error `The first argument must be one of type string or Buffer. Received type number` and launchs the `satus["500"]()` function then the `status["500"]()` function modify headers (after the piped stream), that's the crashing error appear.

To counter that, the stream musn't create error, we can :
- change `stream = Readable.from(bytes)` to `stream = Readable.from(bytes.toString())`
- remove `stream = Readable.from(bytes)` because a correct stream is created with line 334

BUT using .toString() format the buffer and a different charset can produce an error (see `toString()`in  `npm run test`).
This PR is the second (and working) option

##### Contributor checklist

- [ ] Provide tests for the changes (unless documentation-only)
- [x] Provide explanation
- [ ] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
