### PR TITLE
feat(http-server):Add a configuration file to store frequently used configuration values

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Using `npx` you can run the script without installing it first:
 
     npx http-server [path] [options]
 
+Optionally you can create a JavaScript module file 'http-server-config.js' that exports any of the configuration options you want to include.  This can be used to create redirects, apply custom content types etc.
+
 #### Globally via `npm`
 
     npm install --global http-server
@@ -44,6 +46,7 @@ This will install `http-server` globally so that it may be run from the command 
 
 | Command         | 	Description         | Defaults  |
 | -------------  |-------------|-------------|
+| --config | Configuration file to read.  Defaults to http-server-config.js |
 |`-p` or `--port` |Port to use. Use `-p 0` to look for an open port, starting at 8080. It will also read from `process.env.PORT`. |8080 |
 |`-a`   |Address to use |0.0.0.0|
 |`-d`     |Show directory listings |`true` |
@@ -132,6 +135,24 @@ Available on:
   https://192.168.1.101:8080
   https://192.168.1.104:8080
 Hit CTRL-C to stop the server
+```
+
+# configuration file
+You can configure http-server automatically with a file named http-server-config.js, located in the directory
+you run the command from, or as specified by the --config option.
+
+An example configuration:
+```js
+module.exports = {
+  gzip: true,
+  before: [
+	  (req,res) => {
+		  console.log('Hello req', req);
+		  console.log('Hello res', res);
+		  res.emit('next');
+	  },
+  ],
+};
 ```
 
 # Development

--- a/bin/http-server
+++ b/bin/http-server
@@ -10,6 +10,7 @@ var colors     = require('colors/safe'),
 
     fs         = require('fs'),
     url        = require('url');
+const path = require('path');
 var argv = require('minimist')(process.argv.slice(2), {
   alias: {
     tls: 'ssl'
@@ -56,6 +57,7 @@ if (argv.h || argv.help) {
     '  -C --cert    Path to TLS cert file (default: cert.pem)',
     '  -K --key     Path to TLS key file (default: key.pem)',
     '',
+    '  --config     Read the JavaScript file for initial options (http-server-config.js if it exists)',
     '  -r --robots        Respond to /robots.txt [User-agent: *\\nDisallow: /]',
     '  --no-dotfiles      Do not show dotfiles',
     '  --mimetypes        Path to a .types file for custom mimetype definition',
@@ -87,6 +89,7 @@ if (proxyOptions) {
     }
   });
 }
+
 
 if (!argv.s && !argv.silent) {
   logger = {
@@ -155,6 +158,20 @@ function listen(port) {
     username: argv.username || process.env.NODE_HTTP_SERVER_USERNAME,
     password: argv.password || process.env.NODE_HTTP_SERVER_PASSWORD
   };
+
+  const configFile = (typeof argv.config) == 'string' && argv.config || 'http-server-config.js';
+  const isRootConfig = configFile.length && (configFile[0] == '/' || configFile[0] == '\\') ||
+    configFile.length > 1 && configFile[1] == ':';
+  const configPath = isRootConfig && configFile || path.join(process.cwd(), configFile);
+  try {
+    const configLoad = require(configPath);
+    console.log('Read config', configPath);
+    Object.assign(options, configLoad);
+  } catch(e) {
+    if( argv.config ) {
+      throw new Error(`Couldn't load ${configPath}`);
+    }
+  }
 
   if (argv.cors) {
     options.cors = true;


### PR DESCRIPTION
This is a simple change to be able to configure http-server via a javascript file.  This change in particular allows replacing the before methods to perform more complex configuration tasks.  It is theoretically possible to do that in nconf, but it doesn't support JavaScript out of the box, and some sort of more complex configuration is required to do things like renaming the path on the fly, or writing a non-GET handler, dynamically computing time to cache etc.