### PR TITLE
Add graceful shutdown and error handling

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -15,6 +15,17 @@ var argv = require('minimist')(process.argv.slice(2), {
     tls: 'ssl'
   }
 });
+
+process.on('error', (e)=> {
+      let etime = new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '')   
+      console.log(colors.green(etime)) 
+      console.log(colors.red("Fatal error: ")+ e.code + ": "+e.message)
+      let fname = ".httpserver-"+etime.split(" ")[0]+"-"+etime.split(" ")[1]
+      console.log(colors.bold(`Check ${fname} file in this folder.`))
+      fs.writeFileSync(fname, JSON.stringify(e))
+      process.exit(1)
+});
+
 var ifaces = os.networkInterfaces();
 
 process.title = 'http-server';


### PR DESCRIPTION
This PR adds handling for fatal crashes of any type. Just so you don't have to see a giant error stack on your console.  Of course, this might still be an option (WIP).
The output will then be something like:
![image](https://user-images.githubusercontent.com/66487668/147393696-07feb68e-58be-4b7d-8770-a11a0720c5d1.png)


##### Relevant issues

Refers partly to  #665  

##### What needs to be done:

- [ ] Add switch. 
- [ ] Better log file (JSON formatting)

##### Contributor checklist

- [x] Provide tests for the changes (unless documentation-only)
- [ ] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [ x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
