### PR TITLE
Dockerize http-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+yarn-error.log
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:16-alpine
+VOLUME /public
+WORKDIR /srv/http-server
+COPY package.json package-lock.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 8080
+ENTRYPOINT ["node", "./bin/http-server"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ This will install `http-server` globally so that it may be run from the command 
 
 **Note:** Caching is on by default. Add `-c-1` as an option to disable caching.
 
+#### Using Docker
+
+Run the following command in any directory to serve its contents:
+```bash
+docker run -d -p 8080:8080 -v "$(PWD):/public" {your-username}/http-server
+```
+*Now you can visit http://localhost:8080 to view your server*
+
+You can also use [available options](#available-options) as the last argument of `docker run` command.
+
+```bash
+docker run -d -p 8080:8080 -v "$(PWD):/public" {your-username}/http-server "-c-1"
+```
+
 ## Available Options:
 
 | Command         | 	Description         | Defaults  |


### PR DESCRIPTION
Dockerization of http-server

##### Relevant issues

Closes #724 

##### Contributor checklist

- [ ] Provide tests for the changes (unless documentation-only)
- [x] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [x] README.md
    - [x] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable

Maintainers will do the building, tagging and pushing docker images. 
These instructions are only for maintainers to release a new version in docker hub;

### Building and Tagging the Docker Image
- Make sure to checkout the desired version/branch before building docker image for that version
- Run `docker build -t {your-username}/http-server:{new-version} -t {your-username}/http-server:latest .` in project root folder.
*This builds and tags the docker image with "latest" tag and also with the version you provide.*
### Pushing the Docker Image
- After successful build, you can push all tags to your docker repository
- Push the version tag: `docker push {your-username}/http-server:{new-version}`
- Push the "latest" tag: `docker push {your-username}/http-server:latest`

Note: I already have the http-server images built in docker hub in my own repository (which is [tozlu/http-server](https://hub.docker.com/repository/docker/tozlu/http-server)), if you would like to maintain docker images in your own repository, please change README and the build/push scripts above to reflect your username for docker hub.
