### PR TITLE
Make sure headers are not set twice on error

### DIFF
--- a/lib/core/status-handlers.js
+++ b/lib/core/status-handlers.js
@@ -54,7 +54,11 @@ exports['416'] = (res, next) => {
 // flagrant error
 exports['500'] = (res, next, opts) => {
   res.statusCode = 500;
-  res.setHeader('content-type', 'text/html');
+  try {
+    res.setHeader('content-type', 'text/html');
+  } catch (e) {
+    // errors may have triggered headers being sent already, make sure we don't hide the underlying error
+  }
   const error = String(opts.error.stack || opts.error || 'No specified error');
   const html = `${[
     '<!doctype html>',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "man": "./doc/http-server.1",
   "engines": {
-    "node": ">=12"
+    "node": ">=12.16"
   },
   "contributors": [
     {


### PR DESCRIPTION
Handle the case when headers are already sent because of an error -- we want to report the error, not hide it behind "headers already sent". Also bump Node requirement to match versions not affected by #756 .

##### Relevant issues

#756
<!--
    Link to the issue(s) this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
    
    If your PR fixes multiple issues, list them individually like "Fixes #xx1, fixes #xx2, fixes #xx3". This is a quirk of how GitHub links issues.
-->

##### Contributor checklist

- [ ] Provide tests for the changes (unless documentation-only)
- [ ] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [ ] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
