### PR TITLE
Adding websocket upgrade support

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -181,6 +181,12 @@ function HttpServer(options) {
   if (options.timeout !== undefined) {
     this.server.setTimeout(options.timeout);
   }
+  
+  if (typeof options.proxy === 'string') {
+    this.server.on('upgrade', function (request, socket, head) {
+      proxy.ws(request, socket, head);
+    });
+  }
 }
 
 HttpServer.prototype.listen = function () {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -181,10 +181,13 @@ function HttpServer(options) {
   if (options.timeout !== undefined) {
     this.server.setTimeout(options.timeout);
   }
-  
+
   if (typeof options.proxy === 'string') {
     this.server.on('upgrade', function (request, socket, head) {
-      proxy.ws(request, socket, head);
+      proxy.ws(request, socket, head, {
+        target: options.proxy,
+        changeOrigin: true
+      });
     });
   }
 }


### PR DESCRIPTION
Taking inspiration from https://github.com/http-party/http-server/pull/637 and attempting to address the changes requested from the PR review

Adding a handler for an "upgrade" request so that the proxy properly manages the connection to the downstream.

##### Relevant issues

Fixes #142.

##### Contributor checklist

- [ ] Provide tests for the changes (unless documentation-only)
- [x] Documented any new features, CLI switches, etc. (if applicable)
    - [x] Server `--help` output
    - [x] README.md
    - [x] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
