### PR TITLE
Updates details.family check for Node v18

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -226,7 +226,7 @@ function listen(port) {
     } else {
       Object.keys(ifaces).forEach(function (dev) {
         ifaces[dev].forEach(function (details) {
-          if (details.family === 'IPv4') {
+          if (details.family === 'IPv4' || details.family === 4) {
             logger.info(('  ' + protocol + details.address + ':' + chalk.green(port.toString())));
           }
         });


### PR DESCRIPTION
##### Relevant issues

Fixes #815.

Whereas `os.networkinterfaces` used to return a `String` value for `family` like `'IPv4'` in Node v17 and prior, per https://nodejs.org/docs/latest-v17.x/api/os.html#osnetworkinterfaces, it seems to have changed to a `Number` like `4` in Node v18, per https://nodejs.org/docs/latest-v18.x/api/os.html#osnetworkinterfaces.

##### Contributor checklist

- [x] The pull request is being made against the `master` branch

(No existing tests to update.)

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
