### PR TITLE
Close server port on exit

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -242,20 +242,7 @@ function listen(port) {
       }
     }
 
-    logger.info('Hit CTRL-C to stop the server');
-    if (argv.o) {
-      const openHost = host === '0.0.0.0' ? '127.0.0.1' : host;
-      let openUrl = `${protocol}${openHost}:${port}`;
-      if (typeof argv.o === 'string') {
-        openUrl += argv.o[0] === '/' ? argv.o : '/' + argv.o;
-      }
-      logger.info('Open: ' + openUrl);
-      opener(openUrl);
-    }
-
-    // Spacing before logs
-    if (!argv.s) logger.info();
-
+    // Set up "CTRL-C" hook, before printing out "Hit CTRL-C to stop the server"
     function stopServer() {
       server.close();
       logger.info(chalk.red('http-server stopped.'));
@@ -273,5 +260,20 @@ function listen(port) {
         process.emit('SIGINT');
       });
     }
+
+    logger.info('Hit CTRL-C to stop the server');
+
+    if (argv.o) {
+      const openHost = host === '0.0.0.0' ? '127.0.0.1' : host;
+      let openUrl = `${protocol}${openHost}:${port}`;
+      if (typeof argv.o === 'string') {
+        openUrl += argv.o[0] === '/' ? argv.o : '/' + argv.o;
+      }
+      logger.info('Open: ' + openUrl);
+      opener(openUrl);
+    }
+
+    // Spacing before logs
+    if (!argv.s) logger.info();
   });
 }


### PR DESCRIPTION
When http-server is spawned as a child process, when it exits (uppon `SIGINT`/`SIGTERM`), in certain conditions (depending on platforms and the platform conditions, it's hard to reliably reproduce), the port may still be open.

When the parent process tries to run http-server on the same port again, it will fail as the port is still open.

This PR fixes the problem by closing the port on exit.

##### Relevant issues

- https://github.com/http-party/http-server/issues/632
- https://github.com/http-party/http-server/issues/802
- https://stackoverflow.com/questions/40270182/node-child-process-doesnt-release-port-even-after-its-killed-by-parent

##### Contributor checklist

- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag