### PR TITLE
Fix timeout flag behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This will install `http-server` globally so that it may be run from the command 
 |`--cors` |Enable CORS via the `Access-Control-Allow-Origin` header  | |
 |`-o [path]` |Open browser window after starting the server. Optionally provide a URL path to open. e.g.: -o /other/dir/ | |
 |`-c` |Set cache time (in seconds) for cache-control max-age header, e.g. `-c10` for 10 seconds. To disable caching, use `-c-1`.|`3600` |
+|`-t` |Connection timeout in seconds, e.g. `-t60` for 1 minute. To disable timeout, use `-t0`|`120` |
 |`-U` or `--utc` |Use UTC time format in log messages.| |
 |`--log-ip` |Enable logging of the client's IP address |`false` |
 |`-P` or `--proxy` |Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com | |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This will install `http-server` globally so that it may be run from the command 
 |`--cors` |Enable CORS via the `Access-Control-Allow-Origin` header  | |
 |`-o [path]` |Open browser window after starting the server. Optionally provide a URL path to open. e.g.: -o /other/dir/ | |
 |`-c` |Set cache time (in seconds) for cache-control max-age header, e.g. `-c10` for 10 seconds. To disable caching, use `-c-1`.|`3600` |
-|`-t` |Connection timeout in seconds, e.g. `-t60` for 1 minute. To disable timeout, use `-t0`|`120` |
+|`-t` |Connection timeout in seconds, e.g. `-t60` for 1 minute. To disable timeout, use `-t0`.|`120` |
 |`-U` or `--utc` |Use UTC time format in log messages.| |
 |`--log-ip` |Enable logging of the client's IP address |`false` |
 |`-P` or `--proxy` |Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com | |

--- a/bin/http-server
+++ b/bin/http-server
@@ -40,7 +40,7 @@ if (argv.h || argv.help) {
     '  -c           Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
     '               To disable caching, use -c-1.',
     '  -t           Connection timeout in seconds [120], e.g. -t60 for 1 minute.',
-    '               To disable timeout, use -t0',
+    '               To disable timeout, use -t0.',
     '  -U --utc     Use UTC time format in log messages.',
     '  --log-ip     Enable logging of the client\'s IP address',
     '',

--- a/bin/http-server
+++ b/bin/http-server
@@ -3,13 +3,13 @@
 'use strict';
 
 var chalk     = require('chalk'),
-    os         = require('os'),
-    httpServer = require('../lib/http-server'),
-    portfinder = require('portfinder'),
-    opener     = require('opener'),
+  os         = require('os'),
+  httpServer = require('../lib/http-server'),
+  portfinder = require('portfinder'),
+  opener     = require('opener'),
 
-    fs         = require('fs'),
-    url        = require('url');
+  fs         = require('fs'),
+  url        = require('url');
 var argv = require('minimist')(process.argv.slice(2), {
   alias: {
     tls: 'ssl'
@@ -39,7 +39,7 @@ if (argv.h || argv.help) {
     '               Optionally provide a URL path to open the browser window to.',
     '  -c           Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
     '               To disable caching, use -c-1.',
-    '  -t           Connections timeout in seconds [120], e.g. -t60 for 1 minute.',
+    '  -t           Connection timeout in seconds [120], e.g. -t60 for 1 minute.',
     '               To disable timeout, use -t0',
     '  -U --utc     Use UTC time format in log messages.',
     '  --log-ip     Enable logging of the client\'s IP address',
@@ -66,14 +66,14 @@ if (argv.h || argv.help) {
 }
 
 var port = argv.p || argv.port || parseInt(process.env.PORT, 10),
-    host = argv.a || '0.0.0.0',
-    tls = argv.S || argv.tls,
-    sslPassphrase = process.env.NODE_HTTP_SERVER_SSL_PASSPHRASE,
-    proxy = argv.P || argv.proxy,
-    proxyOptions = argv['proxy-options'],
-    utc = argv.U || argv.utc,
-    version = argv.v || argv.version,
-    logger;
+  host = argv.a || '0.0.0.0',
+  tls = argv.S || argv.tls,
+  sslPassphrase = process.env.NODE_HTTP_SERVER_SSL_PASSPHRASE,
+  proxy = argv.P || argv.proxy,
+  proxyOptions = argv['proxy-options'],
+  utc = argv.U || argv.utc,
+  version = argv.v || argv.version,
+  logger;
 
 var proxyOptionsBooleanProps = [
   'ws', 'xfwd', 'secure', 'toProxy', 'prependPath', 'ignorePath', 'changeOrigin',
@@ -94,16 +94,15 @@ if (!argv.s && !argv.silent) {
     request: function (req, res, error) {
       var date = utc ? new Date().toUTCString() : new Date();
       var ip = argv['log-ip']
-          ? req.headers['x-forwarded-for'] || '' +  req.connection.remoteAddress
-          : '';
+        ? req.headers['x-forwarded-for'] || '' +  req.connection.remoteAddress
+        : '';
       if (error) {
         logger.info(
           '[%s] %s "%s %s" Error (%s): "%s"',
           date, ip, chalk.red(req.method), chalk.red(req.url),
           chalk.red(error.status.toString()), chalk.red(error.message)
         );
-      }
-      else {
+      } else {
         logger.info(
           '[%s] %s "%s %s" "%s"',
           date, ip, chalk.cyan(req.method), chalk.cyan(req.url),
@@ -112,8 +111,7 @@ if (!argv.s && !argv.silent) {
       }
     }
   };
-}
-else if (chalk) {
+} else if (chalk) {
   logger = {
     info: function () {},
     request: function () {}
@@ -131,8 +129,7 @@ if (!port) {
     if (err) { throw err; }
     listen(port);
   });
-}
-else {
+} else {
   listen(port);
 }
 
@@ -165,9 +162,8 @@ function listen(port) {
 
   if (proxy) {
     try {
-      new url.URL(proxy)
-    }
-    catch (err) {
+      new url.URL(proxy);
+    } catch (err) {
       logger.info(chalk.red('Error: Invalid proxy url'));
       process.exit(1);
     }
@@ -177,19 +173,17 @@ function listen(port) {
     options.https = {
       cert: argv.C || argv.cert || 'cert.pem',
       key: argv.K || argv.key || 'key.pem',
-      passphrase: sslPassphrase,
+      passphrase: sslPassphrase
     };
     try {
       fs.lstatSync(options.https.cert);
-    }
-    catch (err) {
+    } catch (err) {
       logger.info(chalk.red('Error: Could not find certificate ' + options.https.cert));
       process.exit(1);
     }
     try {
       fs.lstatSync(options.https.key);
-    }
-    catch (err) {
+    } catch (err) {
       logger.info(chalk.red('Error: Could not find private key ' + options.https.key));
       process.exit(1);
     }
@@ -211,7 +205,9 @@ function listen(port) {
       chalk.yellow('\nhttp-server settings: '),
       ([chalk.yellow('CORS: '), argv.cors ? chalk.cyan(argv.cors) : chalk.red('disabled')].join('')),
       ([chalk.yellow('Cache: '), argv.c ? (argv.c === '-1' ? chalk.red('disabled') : chalk.cyan(argv.c + ' seconds')) : chalk.cyan('3600 seconds')].join('')),
-      ([chalk.yellow('Connection Timeout: '), argv.t === '0' ? chalk.red('disabled') : (argv.t ? chalk.cyan(argv.t + ' seconds') : chalk.cyan('120 seconds'))].join('')),
+      ([chalk.yellow('Connection Timeout: '), Math.max(0, argv.t) === 0 ? chalk.red('disabled') :
+        ((!isNaN(argv.t) && !isNaN(parseFloat(argv.t))) ?
+          chalk.cyan(Number(argv.t) + ' seconds') : chalk.cyan('120 seconds'))].join('')),
       ([chalk.yellow('Directory Listings: '), argv.d ? chalk.red('not visible') : chalk.cyan('visible')].join('')),
       ([chalk.yellow('AutoIndex: '), argv.i ? chalk.red('not visible') : chalk.cyan('visible')].join('')),
       ([chalk.yellow('Serve GZIP Files: '), argv.g || argv.gzip ? chalk.cyan('true') : chalk.red('false')].join('')),
@@ -236,8 +232,7 @@ function listen(port) {
     if (typeof proxy === 'string') {
       if (proxyOptions) {
         logger.info('Unhandled requests will be served from: ' + proxy + '. Options: ' + JSON.stringify(proxyOptions));
-      }
-      else {
+      } else {
         logger.info('Unhandled requests will be served from: ' + proxy);
       }
     }

--- a/doc/http-server.1
+++ b/doc/http-server.1
@@ -74,6 +74,12 @@ To disable caching, use \-c \-1.
 Default is 3600.
 
 .TP
+.BI \-t " " \fITIMEOUT\fR
+Connection timeout in seconds, e.g. -t60 for 1 minute.
+To disable timeout, use \-t0.
+Default is 120.
+
+.TP
 .BI \-U ", " \-\-utc
 Use UTC time format in log messages.
 

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -178,8 +178,11 @@ function HttpServer(options) {
     ? require('./shims/https-server-shim')(serverOptions)
     : union.createServer(serverOptions);
 
-  if (options.timeout !== undefined) {
-    this.server.setTimeout(options.timeout);
+  if (isNaN(options.timeout) || isNaN(parseFloat(options.timeout))) {
+    this.server.setTimeout(120);
+  } else {
+    // set custom timeout only if options.timeout is a numeric string
+    this.server.setTimeout(Math.max(0, Number(options.timeout)));
   }
 }
 


### PR DESCRIPTION
Fix timeout flag behavior for 0 value, negative value, empty value, and non-numeric value. Add timeout flag description to README.

#### Example

##### 0 or negative values

`-t0` `-t-42` -> timeout of 0s (i.e. timeout disabled)

##### Empty or non-numeric values

`-t` `-t' '` `-ta1` `-t1a` -> reject timeout value as invalid, and hence fallback to default timeout of 120s

##### Relevant issues

Fixes #804

##### Contributor checklist

- [ ] Provide tests for the changes (unless documentation-only)
- [x] Documented any new features, CLI switches, etc. (if applicable)
    - [x] Server `--help` output
    - [x] README.md
    - [x] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable