### PR TITLE
avoid duplication of .gz suffix

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -201,7 +201,7 @@ module.exports = function createMiddleware(_dir, _options) {
       )
     );
     // determine compressed forms if they were to exist
-    gzippedFile = `${file}.gz`;
+    gzippedFile = file.slice(-3) === ".gz" ? file : `${file}.gz`;
     brotliFile = `${file}.br`;
 
     Object.keys(headers).forEach((key) => {


### PR DESCRIPTION
prevents an issue where when a .gz file is requested it attempts to append an additional .gz suffix prior to checking if the file exists, i.e. the extension becomes .gz.gz

<!--- Describe the changes here. --->

##### Relevant issues

<!--
    Link to the issue(s) this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
    
    If your PR fixes multiple issues, list them individually like "Fixes #xx1, fixes #xx2, fixes #xx3". This is a quirk of how GitHub links issues.
-->

##### Contributor checklist

- [ ] Provide tests for the changes (unless documentation-only)
- [ ] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [ ] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
