### PR TITLE
added code for creating robots.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This will install `http-server` globally so that it may be run from the command 
 |`-S`, `--tls` or `--ssl` |Enable secure request serving with TLS/SSL (HTTPS)|`false`|
 |`-C` or `--cert` |Path to ssl cert file |`cert.pem` | 
 |`-K` or `--key` |Path to ssl key file |`key.pem` |
-|`-r` or `--robots` | Automatically provide a /robots.txt (The content of which defaults to `User-agent: *\nDisallow: /`)  | `false` |
+|`-r` or `--robots` | Automatically creates a /robots.txt file (The content of which defaults to `User-agent: *\nDisallow: /`)  | `false` |
 |`--no-dotfiles` |Do not show dotfiles| |
 |`--mimetypes` |Path to a .types file for custom mimetype definition| |
 |`-h` or `--help` |Print this list and exit. |   |

--- a/bin/http-server
+++ b/bin/http-server
@@ -56,7 +56,7 @@ if (argv.h || argv.help) {
     '  -C --cert    Path to TLS cert file (default: cert.pem)',
     '  -K --key     Path to TLS key file (default: key.pem)',
     '',
-    '  -r --robots        Respond to /robots.txt [User-agent: *\\nDisallow: /]',
+    '  -r --robots        Creates a /robots.txt file [User-agent: *\\nDisallow: /]',
     '  --no-dotfiles      Do not show dotfiles',
     '  --mimetypes        Path to a .types file for custom mimetype definition',
     '  -h --help          Print this list and exit.',

--- a/doc/http-server.1
+++ b/doc/http-server.1
@@ -118,8 +118,8 @@ Passphrase will be read from NODE_HTTP_SERVER_SSL_PASSPHRASE (if set)
 
 .TP
 .BI \-r ", " \-\-robots " " [\fIUSER\-AGENT\fR]
-Respond to /robots.txt request.
-If not specified, uses "User-agent: *\\nDisallow: /]"
+Creates a /robots.txt file.
+Defaults to ["User-agent: *\\nDisallow: /]"
 
 .TP
 .BI \-\-no\-dotfiles

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -110,18 +110,25 @@ function HttpServer(options) {
     } : null));
   }
 
+  // if (options.robots) {
+  //   before.push(function (req, res) {
+  //     if (req.url === '/robots.txt') {
+  //       res.setHeader('Content-Type', 'text/plain');
+  //       var robots = options.robots === true
+  //         ? 'User-agent: *\nDisallow: /'
+  //         : options.robots.replace(/\\n/, '\n');
+
+  //       return res.end(robots);
+  //     }
+
+  //     res.emit('next');
+  //   });
+  // }
+
   if (options.robots) {
-    before.push(function (req, res) {
-      if (req.url === '/robots.txt') {
-        res.setHeader('Content-Type', 'text/plain');
-        var robots = options.robots === true
-          ? 'User-agent: *\nDisallow: /'
-          : options.robots.replace(/\\n/, '\n');
-
-        return res.end(robots);
-      }
-
-      res.emit('next');
+    fs.appendFile(`${this.root}/robots.txt`, 'User-agent: *\nDisallow: /', function (err) {
+      if (err) throw err;
+      // console.log('robots.txt created!');
     });
   }
 


### PR DESCRIPTION
### Description 
Previously, the code was written so as to return text data when [localhost/robots.txt](http://localhost/robots.txt) is visited by providing the `-r` or the `--robots` argument. Now, if the above mentioned arguments are passed, it creates a robots.txt file in the root directory of the server (either `./` or `./public`).
### Relevant issues

Fixes #825 

### Contributor checklist

- [x] Provide tests for the changes (unless documentation-only)
- [x] Documented any new features, CLI switches, etc. (if applicable)
    - [x] Server `--help` output
    - [x] README.md
    - [x] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
