### PR TITLE
Content-Range for 416 Range Not Satisfiable

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -281,7 +281,7 @@ module.exports = function createMiddleware(_dir, _options) {
         let fstream = null;
 
         if (start > end || isNaN(start) || isNaN(end)) {
-          status['416'](res, next);
+          status['416'](res, next, { size: total });
           return;
         }
 

--- a/lib/core/status-handlers.js
+++ b/lib/core/status-handlers.js
@@ -41,8 +41,9 @@ exports['404'] = (res, next) => {
   }
 };
 
-exports['416'] = (res, next) => {
+exports['416'] = (res, next, opts) => {
   res.statusCode = 416;
+  res.setHeader('content-range', 'bytes */' + opts.size)
   if (typeof next === 'function') {
     next();
   } else if (res.writable) {

--- a/test/range.test.js
+++ b/test/range.test.js
@@ -46,8 +46,28 @@ test('range past the end', (t) => {
   });
 });
 
+test('range starts beyond the end', (t) => {
+  t.plan(4);
+  const server = http.createServer(ecstatic(`${__dirname}/public/subdir`));
+  t.on('end', () => { server.close(); });
+
+  server.listen(0, () => {
+    const port = server.address().port;
+    const opts = {
+      uri: `http://localhost:${port}/e.html`,
+      headers: { range: '500-' },
+    };
+    request.get(opts, (err, res, body) => {
+      t.ifError(err);
+      t.equal(res.statusCode, 416, 'range error status code');
+      t.equal(res.headers['content-range'], 'bytes */11');
+      t.equal(body, 'Requested range not satisfiable');
+    });
+  });
+});
+
 test('NaN range', (t) => {
-  t.plan(3);
+  t.plan(4);
   const server = http.createServer(ecstatic(`${__dirname}/public/subdir`));
   t.on('end', () => { server.close(); });
 
@@ -60,13 +80,14 @@ test('NaN range', (t) => {
     request.get(opts, (err, res, body) => {
       t.ifError(err);
       t.equal(res.statusCode, 416, 'range error status code');
+      t.equal(res.headers['content-range'], 'bytes */11');
       t.equal(body, 'Requested range not satisfiable');
     });
   });
 });
 
 test('flipped range', (t) => {
-  t.plan(3);
+  t.plan(4);
   const server = http.createServer(ecstatic(`${__dirname}/public/subdir`));
   t.on('end', () => { server.close(); });
 
@@ -79,6 +100,7 @@ test('flipped range', (t) => {
     request.get(opts, (err, res, body) => {
       t.ifError(err);
       t.equal(res.statusCode, 416, 'range error status code');
+      t.equal(res.headers['content-range'], 'bytes */11');
       t.equal(body, 'Requested range not satisfiable');
     });
   });


### PR DESCRIPTION
Generate `Content-Range: */CONTENT-LENGTH` header for `416 Range Not Satisfiable` response, as for RFC 9110, section 15.5.17

##### Contributor checklist

- [x] Provide tests for the changes (unless documentation-only)
- [ ] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
