### PR TITLE
Apply default background css for icon

### DIFF
--- a/lib/core/show-dir/styles.js
+++ b/lib/core/show-dir/styles.js
@@ -4,7 +4,7 @@ const icons = require('./icons.json');
 
 const IMG_SIZE = 16;
 
-let css = `i.icon { display: block; height: ${IMG_SIZE}px; width: ${IMG_SIZE}px; }\n`;
+let css = `i.icon { display: block; height: ${IMG_SIZE}px; width: ${IMG_SIZE}px; background: no-repeat center; }\n`;
 css += 'table tr { white-space: nowrap; }\n';
 css += 'td.perms {}\n';
 css += 'td.file-size { text-align: right; padding-left: 1em; }\n';


### PR DESCRIPTION
### Description

Related to the PR https://github.com/jfhbrook/node-ecstatic/pull/207 that I made back in 2017

This commit will set the attribute `background-repeat: no-repeat center` which will prevent the icon in the element from being repeated if the size is larger than the actual file size

This is due to differences in some browser installations and/or extensions and without having the `no-repeat` attribute, it'll look very ugly.

### Preview
<img width="625" alt="fix-1" src="https://user-images.githubusercontent.com/4673812/33793652-7c0c1562-dcd0-11e7-8f06-2702402fb03e.png">


### Relevant issues

<!--
    Link to the issue(s) this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
    
    If your PR fixes multiple issues, list them individually like "Fixes #xx1, fixes #xx2, fixes #xx3". This is a quirk of how GitHub links issues.
-->

- https://github.com/jfhbrook/node-ecstatic/pull/207

### Contributor checklist

- [x] The pull request is being made against the `master` branch

### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
