### PR TITLE
Serve compressed files if already exist

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -201,8 +201,8 @@ module.exports = function createMiddleware(_dir, _options) {
       )
     );
     // determine compressed forms if they were to exist
-    gzippedFile = `${file}.gz`;
-    brotliFile = `${file}.br`;
+    gzippedFile = file.endsWith('.gz') ? file : `${file}.gz`;
+    brotliFile = file.endsWith('.br') ? file : `${file}.br`;
 
     Object.keys(headers).forEach((key) => {
       res.setHeader(key, headers[key]);


### PR DESCRIPTION
If file is already compressed (ends with `.gz` or `.br`), no need to add those file extensions.
Sometime files are already compressed and needs to serve with the correct header.
In some cases engines like Unity output some of the files as compressed and others not.

This change allows to serve already compressed files even if `Serve GZIP Files` or `Serve Brotli Files` are false.

I'm not sure how to write a test, or if this change should be documented.
It seems to me like an obvious outcome when serving a `.gz` or `.br` file. So I think it's a bug fix rather than a feature or a change in a feature.

##### Relevant issues

Resolves #844
Resolves #780

##### Contributor checklist

- [ ] Provide tests for the changes (unless documentation-only)
- [ ] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [ ] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
