### PR TITLE
Proxy WebSocket connections with error handling

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -181,6 +181,22 @@ function HttpServer(options) {
   if (options.timeout !== undefined) {
     this.server.setTimeout(options.timeout);
   }
+
+  if (typeof options.proxy === 'string') {
+    this.server.on('upgrade', function (request, socket, head) {
+      proxy.ws(request, socket, head, {
+        target: options.proxy,
+        changeOrigin: true
+      }, function (err, req, res) {
+        if (options.logFn) {
+          options.logFn(req, res, {
+            message: err?.message,
+            status: res?.statusCode });
+        }
+        res.emit('next');
+      });
+    });
+  }
 }
 
 HttpServer.prototype.listen = function () {


### PR DESCRIPTION
Properly proxy WebSocket "upgrade" connections. Without this change any attempt to use `http-server` as a proxy for WebSocket does not work. The code also handles error cases when WebSocket server abruptly closes connection (or a network device dies between client and server). Other PRs fixing the same issue cause http-server to throw error and exit on WebSocket connection errors.

It's a useful addition to http-server for people developing WebSocket applications. There's no WebSocket proxy for Node.js easy to use from command line. This pull request makes http-server more versatile and helps local dev workflows.

The change is as minimal as possible, no code style changes, no whitespace changes etc. Please merge.

<!--- Describe the changes here. --->

##### Relevant issues

Fixes #142.

<!--
    Link to the issue(s) this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
    
    If your PR fixes multiple issues, list them individually like "Fixes #xx1, fixes #xx2, fixes #xx3". This is a quirk of how GitHub links issues.
-->

##### Contributor checklist
Note: cannot provide unit tests for this change.
Note: this doesn't add any new command line options.

- [x] Provide tests for the changes (unless documentation-only)
- [x] Documented any new features, CLI switches, etc. (if applicable)
    - [x] Server `--help` output
    - [x] README.md
    - [x] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable

