### PR TITLE
Added option for custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This will install `http-server` globally so that it may be run from the command 
 |`-e` or `--ext`  |Default file extension if none supplied |`html` | 
 |`-s` or `--silent` |Suppress log messages from output  | |
 |`--cors` |Enable CORS via the `Access-Control-Allow-Origin` header  | |
+|`-H` or `--header` |Add an extra response header (can be used several times)  | |
 |`-o [path]` |Open browser window after starting the server. Optionally provide a URL path to open. e.g.: -o /other/dir/ | |
 |`-c` |Set cache time (in seconds) for cache-control max-age header, e.g. `-c10` for 10 seconds. To disable caching, use `-c-1`.|`3600` |
 |`-U` or `--utc` |Use UTC time format in log messages.| |

--- a/bin/http-server
+++ b/bin/http-server
@@ -37,8 +37,8 @@ if (argv.h || argv.help) {
     '  --cors[=headers]   Enable CORS via the "Access-Control-Allow-Origin" header',
     '                     Optionally provide CORS headers list separated by commas',
     '  -H',
-    '  --header="key: val"',
-    '               Add an arbitrary header (repeatable)',
+    '  --header',
+    '               Add an extra response header (can be used several times)',
     '  -o [path]    Open browser window after starting the server.',
     '               Optionally provide a URL path to open the browser window to.',
     '  -c           Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
@@ -162,11 +162,11 @@ function listen(port) {
   };
 
   function setHeader(str) {
-    const m = /^(.+?)\s*:\s*(.*)$/.exec(str);
-    if (!m) {
-      options.headers[str] = true;
+    const m = /^(.+?)\s*(:\s*(.*))$/.exec(str);
+    if (!m || m.length < 4) {
+      options.headers[str] = '';
     } else {
-      options.headers[m[1]] = m[2];
+      options.headers[m[1]] = m[3];
     }
   }
 

--- a/bin/http-server
+++ b/bin/http-server
@@ -12,7 +12,8 @@ var chalk     = require('chalk'),
     url        = require('url');
 var argv = require('minimist')(process.argv.slice(2), {
   alias: {
-    tls: 'ssl'
+    tls: 'ssl',
+    header: 'H'
   }
 });
 var ifaces = os.networkInterfaces();
@@ -35,6 +36,9 @@ if (argv.h || argv.help) {
     '  -s --silent  Suppress log messages from output',
     '  --cors[=headers]   Enable CORS via the "Access-Control-Allow-Origin" header',
     '                     Optionally provide CORS headers list separated by commas',
+    '  -H',
+    '  --header="key: val"',
+    '               Add an arbitrary header (repeatable)',
     '  -o [path]    Open browser window after starting the server.',
     '               Optionally provide a URL path to open the browser window to.',
     '  -c           Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
@@ -153,13 +157,32 @@ function listen(port) {
     showDotfiles: argv.dotfiles,
     mimetypes: argv.mimetypes,
     username: argv.username || process.env.NODE_HTTP_SERVER_USERNAME,
-    password: argv.password || process.env.NODE_HTTP_SERVER_PASSWORD
+    password: argv.password || process.env.NODE_HTTP_SERVER_PASSWORD,
+    headers: {}
   };
+
+  function setHeader(str) {
+    const m = /^(.+?)\s*:\s*(.*)$/.exec(str);
+    if (!m) {
+      options.headers[str] = true;
+    } else {
+      options.headers[m[1]] = m[2];
+    }
+  }
 
   if (argv.cors) {
     options.cors = true;
     if (typeof argv.cors === 'string') {
       options.corsHeaders = argv.cors;
+    }
+  }
+
+  if (argv.header) {
+    if (Array.isArray(argv.header)) {
+      argv.header.forEach(h => setHeader(h));
+    }
+    else {
+      setHeader(argv.header);
     }
   }
 
@@ -218,6 +241,14 @@ function listen(port) {
       ([chalk.yellow('Serve Brotli Files: '), argv.b || argv.brotli ? chalk.cyan('true') : chalk.red('false')].join('')),
       ([chalk.yellow('Default File Extension: '), argv.e ? chalk.cyan(argv.e) : (argv.ext ? chalk.cyan(argv.ext) : chalk.red('none'))].join(''))
     ].join('\n'));
+
+    if (options.headers) {
+      logger.info(chalk.yellow('Additional Headers:'));
+      for (let k in options.headers) {
+        let v = options.headers[k];
+        logger.info(chalk.yellow(`\t${k}:`) + chalk.cyan(` ${v}`));
+      }
+    }
 
     logger.info(chalk.yellow('\nAvailable on:'));
 

--- a/doc/http-server.1
+++ b/doc/http-server.1
@@ -63,6 +63,10 @@ Enable CORS via the "Access-Control-Allow-Origin" header.
 Optionally provide CORS headers list separated by commas.
 
 .TP
+.BI \-H ", " \-\-header " " \fIHEADER\fR
+Add an extra response header (can be used several times)
+
+.TP
 .BI \-o " " [\fIPATH\fR]
 Open default browser window after starting the server.
 Optionally provide a URL path to open the browser window to.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -114,3 +114,66 @@ test('--proxy requires you to specify a protocol', (t) => {
     t.equal(code, 1);
   });
 });
+
+function doHeaderOptionTest(t, argv, obj) {
+  const options = ['.', '--port', defaultPort].concat(argv);
+  const server = startServer(options);
+
+  tearDown(server, t);
+
+  server.stdout.on('data', (msg) => {
+    checkServerIsRunning(`http://localhost:${defaultPort}`, msg, t, (err, res) => {
+      t.error(err);
+
+      for (const [k, v] of Object.entries(obj)) {
+        t.equal(res.headers[k], v, 'expected header value matches in response');
+      }
+    });
+  });
+}
+
+test('single --header option is applied', (t) => {
+  t.plan(4);
+
+  doHeaderOptionTest(t,
+    ['--header=X-http-server-test-A: hello'],
+    { 'x-http-server-test-a': 'hello' }
+  );
+});
+
+test('single -H option is applied', (t) => {
+  t.plan(4);
+
+  doHeaderOptionTest(t,
+    ['-H', 'X-http-server-test-A: hello'],
+    { 'x-http-server-test-a': 'hello' }
+  );
+});
+
+test('mix of multiple --header and -H options are applied', (t) => {
+  t.plan(7);
+
+  doHeaderOptionTest(t,
+    [
+      '--header=X-http-server-test-A: Lorem ipsum dolor sit amet',
+      '-H', 'X-http-server-test-B: consectetur=adipiscing; elit',
+      '-H', 'X-http-server-test-C: c',
+      '--header=X-http-server-test-D: d'
+    ],
+    {
+      'x-http-server-test-a': 'Lorem ipsum dolor sit amet',
+      'x-http-server-test-b': 'consectetur=adipiscing; elit',
+      'x-http-server-test-c': 'c',
+      'x-http-server-test-d': 'd'
+    }
+  );
+});
+
+test('empty header value is allowed (RFC 7230)', (t) => {
+  t.plan(5);
+
+  doHeaderOptionTest(t,
+    ['-H', 'X-http-server-test-empty-a:', '-H', 'X-http-server-test-empty-b'],
+    { 'x-http-server-test-empty-a': '', 'x-http-server-test-empty-b': '' }
+  );
+});


### PR DESCRIPTION
Difference/improvements over #885:

- Semantically identical to `curl -H` and `curl --header` [^1]
- Empty headers are allowed (RFC 7230)
- Includes tests

Sorry :)

##### Relevant issues

Resolves #884

<!--
    Link to the issue(s) this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
    
    If your PR fixes multiple issues, list them individually like "Fixes #xx1, fixes #xx2, fixes #xx3". This is a quirk of how GitHub links issues.
-->

##### Contributor checklist

- [x] Provide tests for the changes (unless documentation-only)
- [x] Documented any new features, CLI switches, etc. (if applicable)
    - [x] Server `--help` output
    - [x] README.md
    - [x] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable

[^1]: https://curl.se/docs/manpage.html#-H
