### PR TITLE
Fix Node.js CI workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,9 +21,9 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4.2.2
     - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4.1.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x, 18.x]
+        node-version: [16.x, 18.x, 20.x, 21.x, 22.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "man": "./doc/http-server.1",
   "engines": {
-    "node": ">=12.16"
+    "node": ">=16.20.2"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   ],
   "scripts": {
     "start": "node ./bin/http-server",
-    "test": "tap --reporter=spec test/*.test.js",
-    "test-watch": "tap --reporter=spec --watch test/*.test.js"
+    "test": "tap --reporter=terse --allow-incomplete-coverage test/*.test.js",
+    "test-watch": "tap --reporter=terse --allow-incomplete-coverage --watch test/*.test.js"
   },
   "files": [
     "lib",


### PR DESCRIPTION
It seems like upgrading `tap` to `21.x.x` has caused tests to fail on most Node versions in the CI. `tap 21` only supports `node>=20`, so tests fail when run on older versions, also test coverage and reporter settings hanged, so `tap` always returns exit code `1`.

Sorting out all this, I also ran into several other issues:

- Node versions 12 and 14, which are used in tests, are significantly outdated, causing `setup-node` to struggle with locating compatible images. At least, now it shows following error: `Unable to find Node version '12.x' for platform darwin and architecture arm64.`
- `checkout@v2` and `setup-node@v2` are outdated and still rely on Node 12.

To resolve all this I did following
- Downgraded to `tap@20`, which still supports Node 18
- It seems like `spec` reporter is not available anymore, so I changed it for `terse`
- Added `--allow-incomplete-coverage` for `tap` not to return exit code 1
- Dropped `12.x` and `14.x` node versions from  tests job matrix and added `20.x`, `21.x`, and `22.x` to it
- Bumped `engines.node` in package.json to the version CI tests agains in `16.x` scenario

##### Relevant issues

Fixes #904 

##### Contributor checklist

- [ ] Provide tests for the changes (unless documentation-only)
<!--
- [ ] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
-->
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
