### PR TITLE
added proxy config for complex proxy rules

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -51,6 +51,7 @@ if (argv.h || argv.help) {
     '',
     '  -P --proxy       Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
     '  --proxy-options  Pass options to proxy using nested dotted objects. e.g.: --proxy-options.secure false',
+    '  --proxy-config   Pass in .json configuration file. e.g.: ./path/to/config.json',
     '',
     '  --username   Username for basic authentication [none]',
     '               Can also be specified with the env variable NODE_HTTP_SERVER_USERNAME',
@@ -76,6 +77,7 @@ var port = argv.p || argv.port || parseInt(process.env.PORT, 10),
     sslPassphrase = process.env.NODE_HTTP_SERVER_SSL_PASSPHRASE,
     proxy = argv.P || argv.proxy,
     proxyOptions = argv['proxy-options'],
+    proxyConfig = argv['proxy-config'],
     utc = argv.U || argv.utc,
     version = argv.v || argv.version,
     baseDir = argv['base-dir'],
@@ -157,6 +159,7 @@ function listen(port) {
     logFn: logger.request,
     proxy: proxy,
     proxyOptions: proxyOptions,
+    proxyConfig: proxyConfig,
     showDotfiles: argv.dotfiles,
     mimetypes: argv.mimetypes,
     username: argv.username || process.env.NODE_HTTP_SERVER_USERNAME,
@@ -197,6 +200,19 @@ function listen(port) {
       logger.info(chalk.red('Error: Invalid proxy url'));
       process.exit(1);
     }
+  }
+
+  if (proxyConfig) {
+    try {
+      proxyConfig = JSON.parse(fs.readFileSync(proxyConfig));
+    }
+    catch (err) {
+      logger.info(chalk.red('Error: Invalid proxy config file'));
+      process.exit(1);
+    }
+    // Proxy file overrides cli config
+    proxy = undefined;
+    proxyOptions = undefined;
   }
 
   if (tls) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -158,6 +158,37 @@ function HttpServer(options) {
     });
   }
 
+  if (typeof options.proxyConfig === 'object') {
+    var proxy = httpProxy.createProxyServer();
+    before.push(function (req, res) {
+      var matchOptions = {};
+      
+      for (var key in Object.keys(options.proxyConfig)) {
+        var regex = new RegExp(key);
+        if (regex.test(req.url)) {
+          var matchConfig = options.proxyConfig[key];
+          
+          Object.entries(matchConfig.pathRewrites).forEach(rewrite => {
+            req.url = req.url.replace(new RegExp(rewrite[0]), rewrite[1]);
+          });
+          
+          var configEntries = Object.entries(matchConfig);
+          configEntries.forEach(entry => matchOptions.options[entry[0]] = matchOptions.options[entry[1]]);
+          break;
+        }
+      }
+
+      proxy.web(req, res, matchOptions, function (err, req, res) {
+        if (options.logFn) {
+          options.logFn(req, res, {
+            message: err.message,
+            status: res.statusCode });
+        }
+        res.emit('next');
+      });
+    });
+  }
+
   var serverOptions = {
     before: before,
     headers: this.headers,


### PR DESCRIPTION
### Description
Added an additional `--proxy-config` parameter that takes in a `.json` file (with path).
The use of it overrides any other proxy configuration! (Well, it actually disables the other options, not overrides it, but this could also be implemented.)
This allows to write individual rules like:
```json
{
  "/api/*": {
    "target": "localhost:8090",
    "changeOrigin": true,
    "secure": false,
    "ws": false,
    "pathRewrite": {
      "^/api": ""
    }
  },
  "*": {
    "target": "localhost:8070",
    "changeOrigin": false
  }
}
```

### Relevant Issues
This addresses #439, #901 and #906.
I wanted to make a first approach with this to maybe incorporate more functionality different people need. It does rely on a file and therefor isn't CLI only configurable, but with the complexity some rules can have, I think it is not feasible.

### Tasks
There are still a few things to do:
 - [ ] Write tests
 - [ ] Create documentation
 - [ ] Default proxy (use default target and port) behavior if not rule matches
