### PR TITLE
Add handling of brotli/gzip pre-compressed files

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -200,9 +200,9 @@ module.exports = function createMiddleware(_dir, _options) {
         path.relative(path.join('/', baseDir), pathname)
       )
     );
-    // determine compressed forms if they were to exist
-    gzippedFile = `${file}.gz`;
-    brotliFile = `${file}.br`;
+    // determine compressed forms if they were to exist, make sure to handle pre-compressed files, i.e. files with .br/.gz extension. we will serve them "as-is"
+    gzippedFile = file.endsWith('gz') ? file : `${file}.gz`;
+    brotliFile = file.endsWith('br') ? file : `${file}.br`;
 
     Object.keys(headers).forEach((key) => {
       res.setHeader(key, headers[key]);


### PR DESCRIPTION
Serving pre-compressed brotli/gzip files was not working before, because a file.br.br against the pre-compressed file.br check always returned false.

<!--- Describe the changes here. --->

##### Relevant issues

Adresses Fails to serve Unity/Brotli #844
