### PR TITLE
Do not allow CRLF in headers

### DIFF
--- a/lib/core/opts.js
+++ b/lib/core/opts.js
@@ -29,12 +29,26 @@ module.exports = (opts) => {
     return typeof opts[k] !== 'undefined' && opts[k] !== null;
   }
 
+  function validateNoCRLF(str) {
+    if (typeof str === 'string' && (str.includes('\r') || str.includes('\n'))) {
+      throw new Error('Header is not a string or contains CRLF');
+    }
+  }
+
+  function addHeader(key, value) {
+    validateNoCRLF(key);
+    validateNoCRLF(value);
+    headers[key] = value;
+  }
+
   function setHeader(str) {
+    validateNoCRLF(str);
+    
     const m = /^(.+?)\s*:\s*(.*)$/.exec(str);
     if (!m) {
-      headers[str] = true;
+      addHeader(str, true);  // Use addHeader instead of direct assignment
     } else {
-      headers[m[1]] = m[2];
+      addHeader(m[1], m[2]); // Use addHeader instead of direct assignment
     }
   }
 
@@ -135,7 +149,7 @@ module.exports = (opts) => {
           opts[k].forEach(setHeader);
         } else if (opts[k] && typeof opts[k] === 'object') {
           Object.keys(opts[k]).forEach((key) => {
-            headers[key] = opts[k][key];
+            addHeader(key, opts[k][key]);  // Uses same validation path
           });
         } else {
           setHeader(opts[k]);

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -42,6 +42,16 @@ function HttpServer(options) {
     }
   }
 
+  // CRLF injection prevention
+  for ( const [key, value] of Object.entries(options.headers || {}) ) {
+    if (typeof key !== 'string' || typeof value !== 'string') {
+      throw new Error('Header is not a string or contains CRLF');
+    }
+    if (key.includes('\r') || key.includes('\n') || value.includes('\r') || value.includes('\n')) {
+      throw new Error('Header is not a string or contains CRLF');
+    }
+  }
+
   this.headers = options.headers || {};
   this.headers['Accept-Ranges'] = 'bytes';
 

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -84,3 +84,23 @@ test('H array', (t) => {
     t.equal(headers.beep, 'boop');
   });
 });
+
+// CRLF injection prevention
+test('CRLF injection prevention', (t) => {
+  t.plan(1);
+
+  t.throws(() => {
+    const server = http.createServer(
+      ecstatic({
+        root,
+        H: [
+          'X-CRLF-Injection: X\r\nContent-Type: text/html',
+        ],
+        autoIndex: true,
+        defaultExt: 'html',
+      })
+    );
+
+    server.close();
+  }, /Header is not a string or contains CRLF/);
+});


### PR DESCRIPTION
While the underlying HTTP server does in fact throw an error when the response will have invalid HTTP headers, this happens at runtime at the time of the first request rather than immediately after the process is started. This should be considered a fatal configuration error, causing the process to exit immediately.

<!--- Describe the changes here. --->

##### Relevant issues

<!--
    Link to the issue(s) this pull request fixes here, if applicable: "Fixes #xxx" or "Resolves #xxx"
    
    If your PR fixes multiple issues, list them individually like "Fixes #xx1, fixes #xx2, fixes #xx3". This is a quirk of how GitHub links issues.
-->

##### Contributor checklist

- [ ] Provide tests for the changes (unless documentation-only)
- [ ] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [ ] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
