### PR TITLE
cleanup show-dir, fix node version showing as "undefined"

### DIFF
--- a/lib/core/show-dir/index.js
+++ b/lib/core/show-dir/index.js
@@ -73,11 +73,11 @@ module.exports = (opts) => {
         res.setHeader('etag', etag(stat, weakEtags));
         res.setHeader('last-modified', (new Date(stat.mtime)).toUTCString());
         res.setHeader('cache-control', cache);
-        
+
         // A step before render() is called to gives items additional
         // information so that render() can deliver the best user experience
         // possible.
-        function process(dirs, renderFiles, lolwuts) {
+        function prerender(dirs, renderFiles, errs) {
           const filenamesThatExist = new Set();
 
           // Putting filenames in a set first keeps us in O(n) time complexity
@@ -87,7 +87,7 @@ module.exports = (opts) => {
             const renderOptions = {};
             renderFiles[i] = [name, stat, renderOptions];
           }
-          
+
           // Set render options for compressed files
           for (const [name, _stat, renderOptions] of renderFiles) {
             if (
@@ -115,10 +115,10 @@ module.exports = (opts) => {
               renderOptions.uncompressedName = uncompressedName;
             }
           }
-          render(dirs, renderFiles, lolwuts);
+          render(dirs, renderFiles, errs);
         }
 
-        function render(dirs, renderFiles, lolwuts) {
+        function render(dirs, renderFiles, errs) {
           // each entry in the array is a [name, stat] tuple
 
           let html = `${[
@@ -150,7 +150,7 @@ module.exports = (opts) => {
             // Handle compressed files with uncompressed names
             let displayNameHTML;
             let fileSize = sizeToString(file[1], humanReadable, si);
-            
+
             if (file[2] && file[2].uncompressedName) {
               // This is a compressed file, show both names with separate links
               const uncompressedName = he.encode(file[2].uncompressedName);
@@ -184,7 +184,7 @@ module.exports = (opts) => {
 
           dirs.sort((a, b) => a[0].toString().localeCompare(b[0].toString())).forEach(writeRow);
           renderFiles.sort((a, b) => a.toString().localeCompare(b.toString())).forEach(writeRow);
-          lolwuts.sort((a, b) => a[0].toString().localeCompare(b[0].toString())).forEach(writeRow);
+          errs.sort((a, b) => a[0].toString().localeCompare(b[0].toString())).forEach(writeRow);
 
           html += '</table>\n';
           html += `<br><address>Node.js ${
@@ -201,7 +201,7 @@ module.exports = (opts) => {
           }
         }
 
-        sortFiles(dir, files, (lolwuts, dirs, sortedFiles) => {
+        sortFiles(dir, files, (errs, dirs, sortedFiles) => {
           // It's possible to get stat errors for all sorts of reasons here.
           // Unfortunately, our two choices are to either bail completely,
           // or just truck along as though everything's cool. In this case,
@@ -222,10 +222,10 @@ module.exports = (opts) => {
                 return;
               }
               dirs.unshift(['..', s]);
-              process(dirs, sortedFiles, lolwuts);
+              prerender(dirs, sortedFiles, errs);
             });
           } else {
-            process(dirs, sortedFiles, lolwuts);
+            prerender(dirs, sortedFiles, errs);
           }
         });
       });

--- a/lib/core/show-dir/last-modified-to-string.js
+++ b/lib/core/show-dir/last-modified-to-string.js
@@ -1,6 +1,10 @@
 'use strict';
 
 module.exports = function lastModifiedToString(stat) {
+  if (!stat.mtime) {
+    // stat error (eg, broken symlink)
+    return 'Unknown Date';
+  }
   const t = new Date(stat.mtime);
   return (('0' + (t.getDate())).slice(-2) + '-' +
           t.toLocaleString('default', { month: 'short' }) + '-' +

--- a/lib/core/show-dir/perms-to-string.js
+++ b/lib/core/show-dir/perms-to-string.js
@@ -2,7 +2,7 @@
 
 module.exports = function permsToString(stat) {
   if (!stat.isDirectory || !stat.mode) {
-    return '???!!!???';
+    return '????!!!???';
   }
 
   const dir = stat.isDirectory() ? 'd' : '-';


### PR DESCRIPTION
In the show-dir code, a function named `process` was shadowing the global process, causing it to render `undefined` to the html (introduced by https://github.com/http-party/http-server/commit/a8cd44cbf37129e2eb9794d07dd9311bf63e73fe)

Also stopped it from rendering glitched dates when there's a stat error

before:
<img width="497" height="208" alt="image" src="https://github.com/user-attachments/assets/996599e0-b5b7-4f2a-996c-d4fc767e298d" />

after:
<img width="428" height="155" alt="image" src="https://github.com/user-attachments/assets/91303601-e421-484e-9005-a1fc7b057683" />


##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
