### PR TITLE
fix: resolve colors undefined and logger.warning errors in CLI

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -112,10 +112,10 @@ if (nopanic){
   process.on('error', (e)=> {
     // Results in a string like "2021-12-27 14:56:31"
     const etime = new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '');
-    console.log(colors.green(etime));
-    console.log(`${colors.red('Fatal error: ')}${e.code}: ${e.message}`);
+    console.log(chalk.green(etime));
+    console.log(`${chalk.red('Fatal error: ')}${e.code}: ${e.message}`);
     const filename = `httpserver-${etime.split(' ').join('_')}.log`;
-    console.log(colors.bold(`Check ${filename} file in this folder.`));
+    console.log(chalk.bold(`Check ${filename} file in this folder.`));
     fs.writeFileSync(filename, JSON.stringify(e));
     process.exit(1);
   });
@@ -137,6 +137,7 @@ if (proxyOptions) {
 if (!argv.s && !argv.silent) {
   logger = {
     info: console.log,
+    warning: console.warn,
     request: function (req, res, error) {
       var date = utc ? new Date().toUTCString() : new Date();
       var ip = argv['log-ip']
@@ -230,7 +231,7 @@ function listen(port) {
 
   if (websocket) {
     if (!proxy) {
-      logger.warning(colors.yellow('WebSocket proxy will not be enabled because proxy is not enabled'));
+      logger.warning(chalk.yellow('WebSocket proxy will not be enabled because proxy is not enabled'));
     } else {
       options.websocket = true;
     }


### PR DESCRIPTION
## fix: resolve colors undefined and logger.warning errors in CLI
This PR fixes two critical issues in the  `bin/http-server`
 CLI that caused crashes when using the --websocket flag or when encountering fatal errors with --no-panic:

- **Fixed ReferenceError**: colors is not defined: The codebase uses chalk for terminal styling, but several locations were incorrectly referencing a colors variable that was never imported. All instances have been updated to use chalk.
- **Fixed TypeError: logger.warning is not a function:** The logger object used for CLI output was missing a warning method. This caused a crash when the server tried to warn the user that WebSocket proxying requires a proxy target. I have added warning: console.warn to the logger definition.

##### Relevant issues
fixes #949

##### Contributor checklist

- [ ] Provide tests for the changes (unless documentation-only)
- [ ] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [x] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable