### PR TITLE
Allow setting changeOrigin to false

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -167,13 +167,13 @@ function HttpServer(options) {
         if (!minimatch(req.url, key)) continue;
         req.proxy ??= {};
         var matchConfig = options.proxyConfig[key];
-        
+
         if (matchConfig.pathRewrite) {
           Object.entries(matchConfig.pathRewrite).forEach(rewrite => {
             req.url = req.url.replace(new RegExp(rewrite[0]), rewrite[1]);
           });
         }
-        
+
         var configEntries = Object.entries(matchConfig).filter(entry => entry[0] !== "pathRewrite");
         configEntries.forEach(entry => req.proxy[entry[0]] = entry[1]);
         break;
@@ -219,10 +219,14 @@ function HttpServer(options) {
 
   if (typeof options.proxy === 'string') {
     var proxyOptions = options.proxyOptions || {};
+
+    if (proxyOptions.changeOrigin == null) {
+        proxyOptions.changeOrigin = true;
+    }
+
     var proxy = httpProxy.createProxyServer({
       ...proxyOptions,
       target: options.proxy,
-      changeOrigin: true,
     });
     before.push(function (req, res) {
       proxy.web(req, res, {}, function (err, req, res) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -167,13 +167,13 @@ function HttpServer(options) {
         if (!minimatch(req.url, key)) continue;
         req.proxy ??= {};
         var matchConfig = options.proxyConfig[key];
-
+        
         if (matchConfig.pathRewrite) {
           Object.entries(matchConfig.pathRewrite).forEach(rewrite => {
             req.url = req.url.replace(new RegExp(rewrite[0]), rewrite[1]);
           });
         }
-
+        
         var configEntries = Object.entries(matchConfig).filter(entry => entry[0] !== "pathRewrite");
         configEntries.forEach(entry => req.proxy[entry[0]] = entry[1]);
         break;


### PR DESCRIPTION
If changeOrigin is set to false in the proxyOptions, it will now be honoured.

##### Relevant issues

Fixes #831.

##### Contributor checklist

- [ ] Provide tests for the changes (unless documentation-only)
- [ ] Documented any new features, CLI switches, etc. (if applicable)
    - [ ] Server `--help` output
    - [ ] README.md
    - [ ] doc/http-server.1 (use the same format as other entries)
- [ ] The pull request is being made against the `master` branch

##### Maintainer checklist

- [ ] Assign a version triage tag
- [ ] Approve tests if applicable
