### PR TITLE
fix: remove unreachable return in ensureUriEncoded

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -36,7 +36,6 @@ function decodePathname(pathname) {
 
 const nonUrlSafeCharsRgx = /[\x00-\x1F\x20\x7F-\uFFFF]+/g;
 function ensureUriEncoded(text) {
-  return text
   return String(text).replace(nonUrlSafeCharsRgx, encodeURIComponent);
 }
 


### PR DESCRIPTION
Remove unreachable return that prevented URI encoding.