### PR TITLE
fix: preserve CJK/Unicode characters in directory listing for non-browser clients

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -36,7 +36,6 @@ function decodePathname(pathname) {
 
 const nonUrlSafeCharsRgx = /[\x00-\x1F\x20\x7F-\uFFFF]+/g;
 function ensureUriEncoded(text) {
-  return text
   return String(text).replace(nonUrlSafeCharsRgx, encodeURIComponent);
 }
 

--- a/lib/core/show-dir/index.js
+++ b/lib/core/show-dir/index.js
@@ -15,6 +15,17 @@ const status = require('../status-handlers');
 const supportedIcons = styles.icons;
 const css = styles.css;
 
+// Only escape HTML-unsafe characters, preserve CJK/unicode as-is for
+// clients that do not decode HTML entities (e.g. Switch DBI).
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 module.exports = (opts) => {
   // opts are parsed by opts.js, defaults already applied
   const cache = opts.cache;
@@ -69,7 +80,7 @@ module.exports = (opts) => {
           files = files.filter(filename => filename.slice(0, 1) !== '.');
         }
 
-        res.setHeader('content-type', 'text/html');
+        res.setHeader('content-type', 'text/html; charset=utf-8');
         res.setHeader('etag', etag(stat, weakEtags));
         res.setHeader('last-modified', (new Date(stat.mtime)).toUTCString());
         res.setHeader('cache-control', cache);
@@ -127,11 +138,11 @@ module.exports = (opts) => {
             '  <head>',
             '    <meta charset="utf-8">',
             '    <meta name="viewport" content="width=device-width">',
-            `    <title>Index of ${he.encode(pathname)}</title>`,
+            `    <title>Index of ${escapeHtml(pathname)}</title>`,
             `    <style type="text/css">${css}</style>`,
             '  </head>',
             '  <body>',
-            `<h1>Index of ${he.encode(pathname)}</h1>`,
+            `<h1>Index of ${escapeHtml(pathname)}</h1>`,
           ].join('\n')}\n`;
 
           html += '<table>';
@@ -144,7 +155,7 @@ module.exports = (opts) => {
 
             // append trailing slash and query for dir entry
             if (isDir) {
-              href += `/${he.encode((parsed.search) ? parsed.search : '')}`;
+              href += `/${escapeHtml((parsed.search) ? parsed.search : '')}`;
             }
 
             // Handle compressed files with uncompressed names
@@ -153,8 +164,8 @@ module.exports = (opts) => {
 
             if (file[2] && file[2].uncompressedName) {
               // This is a compressed file, show both names with separate links
-              const uncompressedName = he.encode(file[2].uncompressedName);
-              const compressedName = he.encode(file[0]);
+              const uncompressedName = escapeHtml(file[2].uncompressedName);
+              const compressedName = escapeHtml(file[0]);
               const uncompressedHref = `./${encodeURIComponent(file[2].uncompressedName)}`;
               const asterisk = `<span title="served from compressed file">*</span>`;
               displayNameHTML = `<a href="${uncompressedHref}">${uncompressedName}</a>` +
@@ -162,7 +173,7 @@ module.exports = (opts) => {
               fileSize += '*';
             } else {
               // Regular file or directory
-              displayNameHTML = `<a href="${href}">${he.encode(file[0]) + ((isDir) ? '/' : '')}</a>`;
+              displayNameHTML = `<a href="${href}">${escapeHtml(file[0]) + ((isDir) ? '/' : '')}</a>`;
             }
 
             const ext = file[0].split('.').pop();
@@ -191,12 +202,12 @@ module.exports = (opts) => {
             process.version
             }/ <a href="https://github.com/http-party/http-server">http-server</a> ` +
             `server running @ ${
-            he.encode(req.headers.host || '')}</address>\n` +
+            escapeHtml(req.headers.host || '')}</address>\n` +
             '</body></html>'
           ;
 
           if (!failed) {
-            res.writeHead(200, { 'Content-Type': 'text/html' });
+            res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
             res.end(html);
           }
         }


### PR DESCRIPTION
## Problem

When browsing directory listings from non-browser HTTP clients (e.g. Nintendo Switch DBI), CJK characters (Chinese, Japanese, Korean) in file and directory names are displayed as HTML entity codes like `&#x5DE8;&#x4E1D;&#x4E8B;` instead of the actual characters.

This happens because `he.encode()` converts all non-ASCII characters into numeric HTML entities (e.g. `巨` → `&#x5DE8;`). Standard web browsers decode these entities automatically, so the issue is invisible in browsers. However, lightweight HTTP clients that don't implement full HTML parsing display the raw entity codes, making CJK filenames completely unreadable.

## Root Cause

1. **`he.encode()` over-escapes non-ASCII characters**: The `he` library's `encode()` function converts all non-ASCII characters (including CJK) to `&#x...;` HTML entities. Non-browser clients display these entities as-is.

2. **Missing `charset=utf-8` in Content-Type header**: The directory listing response header was set to `text/html` without specifying charset, which can cause encoding issues in clients that don't sniff the `<meta charset>` tag.

3. **`ensureUriEncoded()` function bug**: An unreachable `return` statement on line 39 prevented the URL encoding logic from ever executing, causing non-ASCII characters in redirect URLs to remain unencoded.

## Fix

- Replace `he.encode()` with a custom `escapeHtml()` function that only escapes the 5 HTML-unsafe characters (`& < > " '`) while preserving CJK/Unicode characters as raw UTF-8.
- Add `charset=utf-8` to the `Content-Type` response header for directory listings.
- Remove the dead `return text` line in `ensureUriEncoded()` so URL encoding works correctly.

## Files Changed

- `lib/core/show-dir/index.js` - escapeHtml() + charset fix
- `lib/core/index.js` - ensureUriEncoded() bug fix